### PR TITLE
fix: fix tests for hard constraints

### DIFF
--- a/docs/facts/examples.ipynb
+++ b/docs/facts/examples.ipynb
@@ -12,17 +12,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 1,
    "id": "f5e5eb27",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from draco import dict_union, dict_to_facts, check_spec\n",
+    "from draco import dict_union, dict_to_facts, check_spec, get_violations\n",
     "\n",
     "def show(*args):\n",
     "    spec = dict_union(*args)\n",
     "    prog = dict_to_facts(spec)\n",
-    "    assert check_spec(prog), \"Invalid spec\"\n",
+    "    if not check_spec(prog):\n",
+    "        print(\"\\n\".join(prog))\n",
+    "        print(get_violations(prog))\n",
+    "        assert False, \"Invalid spec\"\n",
     "    return prog"
    ]
   },

--- a/draco/asp/hard.lp
+++ b/draco/asp/hard.lp
@@ -3,12 +3,12 @@
 % @hard(text_mark_without_text_channel) Text mark requires text encoding.
 violation(text_mark_without_text_channel) :-
     attribute((mark,type),M,text),
-    not attribute(has_channel,M,text).
+    not attribute(mark_channel,M,text).
 
 % @hard(text_channel_without_text_mark) Text channel requires text mark.
 violation(text_channel_without_text_mark) :-
-    not attribute((mark,type),M,text),
-    attribute(has_channel,M,text).
+    attribute(mark_channel,M,text),
+    not attribute((mark,type),M,text).
 
 % @hard(bin_and_aggregate) Cannot bin and aggregate.
 violation(bin_and_aggregate) :-
@@ -22,7 +22,6 @@ violation(no_encodings) :-
 
 % @hard(repeat_channel) Cannot use single channels twice for the same mark.
 violation(repeat_channel) :-
-    entity(mark,_,M),
     entity(encoding,M,E1),
     entity(encoding,M,E2),
     attribute((encoding,channel),E1,C),
@@ -40,10 +39,8 @@ violation(count_with_field) :-
     attribute((encoding,aggregate),E,count),
     attribute((encoding,field),E,_).
 
-
 % @hard(point_tick_bar_without_x_or_y) Point, tick, and bar require x or y channel.
 violation(point_tick_bar_without_x_or_y) :-
-    entity(encoding,_,E),
-    attribute((mark,type),E,(point;tick;bar)),
-    not attribute((encoding,channel),E,x),
-    not attribute((encoding,channel),E,y).
+    attribute((mark,type),M,(point;tick;bar)),
+    not attribute(mark_channel,M,x),
+    not attribute(mark_channel,M,y).

--- a/draco/asp/helpers.lp
+++ b/draco/asp/helpers.lp
@@ -1,6 +1,6 @@
 % ====== Helpers ======
 
-% @helper(has_channel) Whether a mark has an encoding for a channel.
-attribute(has_channel,M,C) :-
+% @helper(mark_channel) Whether a mark has an encoding for a channel.
+attribute(mark_channel,M,C) :-
     entity(encoding,M,E),
     attribute((encoding,channel),E,C).

--- a/draco/spec.py
+++ b/draco/spec.py
@@ -29,7 +29,7 @@ def get_violations(spec: Union[str, Iterable[str]]):
     Internally, Draco checks against the definitions, constraints, helpers,
     and hard constraints.
 
-    :param spec: The specification top check
+    :param spec: The specification to check
     """
     if not isinstance(spec, str):
         spec = "\n".join(spec)

--- a/draco/tests/test_hard.py
+++ b/draco/tests/test_hard.py
@@ -1,100 +1,123 @@
-from draco import is_satisfiable
 from draco.asp_utils import Block
 from draco.programs import hard, helpers
+from draco.run import is_satisfiable, run_clingo
+
+
+def list_violations(program: str):
+    try:
+        model = next(run_clingo(helpers.program + program, 1))
+
+        return [
+            symbol.arguments[0].name
+            for symbol in model.answer_set
+            if symbol.name == "violation"
+        ]
+    except StopIteration:
+        return None
+
+
+def no_violations(program: str):
+    return is_satisfiable(helpers.program + program + ":- violation(_).")
 
 
 def test_text_mark_without_text_channel():
     b = hard.blocks["text_mark_without_text_channel"]
     assert isinstance(b, Block)
-    p = helpers.program + b.program
 
-    assert is_satisfiable(
-        p
+    assert no_violations(
+        b.program
         + """
     attribute((mark,type),m1,text).
     entity(encoding,m1,e1).
     attribute((encoding,channel),e1,text).
-
-    :- violation(_).
     """
     )
 
-    assert is_satisfiable(
-        p
+    assert no_violations(
+        b.program
         + """
     attribute((mark,type),m1,text).
     entity(encoding,m1,e1).
     attribute((encoding,channel),e1,x).
     entity(encoding,m1,e2).
     attribute((encoding,channel),e2,text).
-
-    :- violation(_).
     """
     )
 
-    assert not is_satisfiable(
-        p
-        + """
+    # no encoding
+    assert (
+        list_violations(
+            b.program
+            + """
+    attribute((mark,type),m1,text).
+    """
+        )
+        == ["text_mark_without_text_channel"]
+    )
+
+    assert (
+        list_violations(
+            b.program
+            + """
     attribute((mark,type),m1,text).
     entity(encoding,m1,e1).
     attribute((encoding,channel),e1,x).
     entity(encoding,m1,e2).
     attribute((encoding,channel),e2,y).
-
-    :- violation(_).
     """
+        )
+        == ["text_mark_without_text_channel"]
     )
 
-    assert not is_satisfiable(
-        p
-        + """
+    # text encoding for a different mark
+    assert (
+        list_violations(
+            b.program
+            + """
     attribute((mark,type),m1,text).
     entity(encoding,m1,e1).
     attribute((encoding,channel),e1,x).
     entity(encoding,m1,e2).
     attribute((encoding,channel),e2,y).
     attribute((encoding,channel),e3,text).
-
-    :- violation(_).
     """
+        )
+        == ["text_mark_without_text_channel"]
     )
 
 
 def test_text_channel_without_text_mark():
     b = hard.blocks["text_channel_without_text_mark"]
     assert isinstance(b, Block)
-    p = helpers.program + b.program
 
-    assert is_satisfiable(
-        p
+    assert no_violations(
+        b.program
         + """
     attribute((mark,type),m1,text).
     entity(encoding,m1,e1).
     attribute((encoding,channel),e1,text).
-
-    :- violation(_).
     """
     )
 
-    assert not is_satisfiable(
-        p
-        + """
+    assert (
+        list_violations(
+            b.program
+            + """
     attribute((mark,type),m1,bar).
     entity(encoding,m1,e1).
     attribute((encoding,channel),e1,text).
-
-    :- violation(_).
     """
+        )
+        == ["text_channel_without_text_mark"]
     )
 
 
 def test_bin_and_aggregate():
     b = hard.blocks["bin_and_aggregate"]
     assert isinstance(b, Block)
-    p = b.program
 
-    assert is_satisfiable(
-        p
+    assert no_violations(
+        b.program
         + """
     entity(encoding,root,e1).
     attribute((encoding,channel),e1,x).
@@ -102,215 +125,193 @@ def test_bin_and_aggregate():
     entity(encoding,root,e2).
     attribute((encoding,channel),e2,y).
     attribute((encoding,aggregate),e2,count).
-
-    :- violation(_).
     """
     )
 
-    assert not is_satisfiable(
-        p
-        + """
+    assert (
+        list_violations(
+            b.program
+            + """
     entity(encoding,root,e1).
     attribute((encoding,channel),e1,x).
     attribute((encoding,binning),e1,10).
     attribute((encoding,aggregate),e1,count).
-
-    :- violation(_).
     """
+        )
+        == ["bin_and_aggregate"]
     )
 
 
 def test_no_encodings():
     b = hard.blocks["no_encodings"]
     assert isinstance(b, Block)
-    p = b.program
 
-    assert is_satisfiable(
-        p
+    assert no_violations(
+        b.program
         + """
     entity(mark,root,1).
     entity(encoding,1,2).
-
-    :- violation(_).
     """
     )
 
-    assert not is_satisfiable(
-        p
-        + """
+    assert (
+        list_violations(
+            b.program
+            + """
     entity(mark,root,1).
     entity(encoding,1,2).
     entity(mark,root,3).
-
-    :- violation(_).
     """
+        )
+        == ["no_encodings"]
     )
 
 
 def test_repeat_channel():
     b = hard.blocks["repeat_channel"]
     assert isinstance(b, Block)
-    p = helpers.program + b.program
 
-    assert is_satisfiable(
-        p
+    # different channels
+    assert no_violations(
+        b.program
         + """
+    entity(mark,root,m0).
+    entity(encoding,m0,e0).
+    entity(encoding,m0,e1).
     attribute((encoding,channel),e0,x).
     attribute((encoding,channel),e1,y).
-
-
-    :- violation(_).
     """
     )
 
-    assert is_satisfiable(
-        p
+    # no channel
+    assert no_violations(
+        b.program
         + """
-    entity(encoding,1,2).
-    attribute((encoding,channel),2,x).
-    attribute((encoding,field),2,temperature).
-    entity(scale,root,3).
-    attribute((scale,channel),3,x).
-
-    :- violation(_).
+    entity(mark,root,m0).
     """
     )
 
-    assert is_satisfiable(
-        p
+    # different marks
+    assert no_violations(
+        b.program
         + """
-    entity(encoding,1,2).
-    attribute((encoding,channel),2,x).
-    attribute((encoding,field),2,temperature).
-    entity(encoding,1,3).
-    attribute((encoding,channel),3,x).
-
-    :- violation(_).
+    entity(mark,root,m0).
+    entity(mark,root,m1).
+    entity(encoding,m0,e0).
+    entity(encoding,m1,e1).
+    attribute((encoding,channel),e0,x).
+    attribute((encoding,channel),e1,x).
     """
     )
 
-    assert is_satisfiable(
-        p
-        + """
-    entity(mark,root,1).
-
-    entity(encoding,1,2).
-    attribute((encoding,channel),2,x).
-    attribute((encoding,field),2,temperature).
-
-    entity(encoding,1,3).
-    attribute((encoding,channel),3,y).
-
-    :- violation(_).
+    assert (
+        list_violations(
+            b.program
+            + """
+    entity(mark,root,m0).
+    entity(encoding,m0,e0).
+    entity(encoding,m0,e1).
+    attribute((encoding,channel),e0,x).
+    attribute((encoding,channel),e1,x).
     """
-    )
-
-    assert not is_satisfiable(
-        p
-        + """
-    entity(mark,root,1).
-
-    entity(encoding,1,2).
-    attribute((encoding,channel),2,x).
-    attribute((encoding,field),2,temperature).
-
-    entity(encoding,1,3).
-    attribute((encoding,channel),3,x).
-
-    :- violation(_).
-    """
+        )
+        == ["repeat_channel"]
     )
 
 
 def test_encoding_no_field_and_not_count():
     b = hard.blocks["encoding_no_field_and_not_count"]
     assert isinstance(b, Block)
-    p = b.program
-    assert is_satisfiable(
-        p
+
+    assert no_violations(
+        b.program
         + """
     entity(encoding,root,1).
     attribute((encoding,field),1,temp).
     attribute((encoding,aggregate),1,mean).
-
-
-    :- violation(_).
     """
     )
 
-    assert is_satisfiable(
-        p
+    assert no_violations(
+        b.program
         + """
     entity(encoding,root,1).
     attribute((encoding,aggregate),1,count).
-
-
-    :- violation(_).
     """
     )
 
-    assert not is_satisfiable(
-        p
-        + """
+    assert (
+        list_violations(
+            b.program
+            + """
     entity(encoding,root,1).
     attribute((encoding,aggregate),1,mean).
-
-
-    :- violation(_).
     """
+        )
+        == ["encoding_no_field_and_not_count"]
     )
 
 
 def test_count_with_field():
     b = hard.blocks["count_with_field"]
     assert isinstance(b, Block)
-    p = b.program
 
-    assert is_satisfiable(
-        p
+    assert no_violations(
+        b.program
         + """
     entity(encoding,root,1).
     attribute((encoding,aggregate),1,count).
-
-
-    :- violation(_).
     """
     )
 
-    assert not is_satisfiable(
-        p
-        + """
+    assert (
+        list_violations(
+            b.program
+            + """
+    entity(encoding,root,1).
     attribute((encoding,aggregate),1,count).
     attribute((encoding,field),1,temp).
-
-    :- violation(_).
     """
+        )
+        == ["count_with_field"]
     )
 
 
 def test_point_tick_bar_without_x_or_y():
     b = hard.blocks["point_tick_bar_without_x_or_y"]
     assert isinstance(b, Block)
-    p = b.program
 
-    assert is_satisfiable(
-        p
+    assert no_violations(
+        b.program
         + """
-    entity(encoding,root,1).
-    attribute((mark,type),1,tick).
-    attribute((encoding,channel),1,x).
-
-
-    :- violation(_).
+    entity(mark,root,m0).
+    attribute((mark,type),m0,tick).
+    entity(encoding,m0,e0).
+    attribute((encoding,channel),e0,x).
     """
     )
 
-    assert not is_satisfiable(
-        p
+    assert no_violations(
+        b.program
         + """
-    entity(encoding,root,1).
-    attribute((mark,type),1,tick).
-
-    :- violation(_).
+    entity(mark,root,m0).
+    attribute((mark,type),m0,tick).
+    entity(encoding,m0,e0).
+    attribute((encoding,channel),e0,x).
+    entity(encoding,m0,e1).
+    attribute((encoding,channel),e1,color).
     """
+    )
+
+    assert (
+        list_violations(
+            b.program
+            + """
+    entity(mark,root,m0).
+    attribute((mark,type),m0,tick).
+    entity(encoding,m0,e0).
+    attribute((encoding,channel),e0,color).
+    """
+        )
+        == ["point_tick_bar_without_x_or_y"]
     )

--- a/draco/tests/test_hard.py
+++ b/draco/tests/test_hard.py
@@ -20,6 +20,10 @@ def no_violations(program: str):
     return is_satisfiable(helpers.program + program + ":- violation(_).")
 
 
+def test_list_violations():
+    assert list_violations(":- a. :- not a.") is None
+
+
 def test_text_mark_without_text_channel():
     b = hard.blocks["text_mark_without_text_channel"]
     assert isinstance(b, Block)

--- a/draco/tests/test_spec_utils.py
+++ b/draco/tests/test_spec_utils.py
@@ -39,6 +39,7 @@ def test_get_violations():
             "field": [{"name": "temperature", "type": "number"}],
             "mark": [
                 {
+                    # invalid mark
                     "type": "tickk",
                     "encoding": [{"channel": "x", "field": "temperature"}],
                 }
@@ -50,8 +51,7 @@ def test_get_violations():
 
 
 def test_get_violations_satisfiable():
-    prog = ":- a."
-    assert get_violations(prog) == []
+    assert get_violations("") == []
 
 
 def test_get_violations_unsatisfiable():


### PR DESCRIPTION
* improve the unit tests for hard constraints with `no_violations` and `list_violations` helpers
* fixes #193
* simplify hard constraints by removing unnecessary entity declartions