### PR TITLE
ci: configure black version in ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: psf/black@21.12b0
+      - uses: psf/black@stable
         with:
           version: "21.12b0"
       - uses: py-actions/flake8@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,4 +41,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - uses: psf/black@21.12b0
+        with:
+          version: "21.12b0"
       - uses: py-actions/flake8@v2


### PR DESCRIPTION
from their [doc](https://black.readthedocs.io/en/stable/integrations/github_actions.html):
> We recommend the use of the @stable tag, but per version tags also exist if you prefer that. Note that the action’s version you select is independent of the version of Black the action will use.
The version of Black the action will use can be configured via version. 

Without specifying version, the default is using the latest(22.1.0)