### PR TITLE
docs: improve docs

### DIFF
--- a/docs/api/draco.ipynb
+++ b/docs/api/draco.ipynb
@@ -13,7 +13,11 @@
   {
    "cell_type": "markdown",
    "id": "c61fd747",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Class Documentation\n",
     "\n",

--- a/docs/api/facts.ipynb
+++ b/docs/api/facts.ipynb
@@ -2,16 +2,24 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Fact Utils\n",
     "\n",
-    "Generating facts in the expected format can be tedious. To make it easier to put data into and get data our of Draco, we an API to convert nested data to facts and vice versa."
+    "Generating facts in the expected format can be tedious. To make it easier to put data into and get data our of Draco, we provide an API to convert nested data to facts and vice versa."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Available functions\n",
     "\n",
@@ -23,7 +31,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Usage Example"
    ]
@@ -31,7 +43,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from draco import dict_to_facts, answer_set_to_dict, run_clingo\n",
@@ -41,7 +57,11 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -68,7 +88,11 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -93,7 +117,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": []
   }

--- a/docs/api/run.ipynb
+++ b/docs/api/run.ipynb
@@ -3,11 +3,15 @@
   {
    "cell_type": "markdown",
    "id": "mechanical-pointer",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Run\n",
     "\n",
-    "Draco can run programs in the Clingo solver. `draco.run` exposes the low-level functions to run a program in the solver and get back the satisfying models with the answer sets.\n",
+    "Draco can run programs in the [Clingo solver](https://potassco.org/clingo/). `draco.run` exposes the low-level functions to run a program in the solver and get back the satisfying models with the answer sets.\n",
     "\n",
     "Draco uses these methods in the [high-level APIs for checking specifications](draco.ipynb). If you use this API, make sure to read the [documentation of the Clingo Python API](https://potassco.org/clingo/python-api/current/). It covers how to work with answer sets and symbols."
    ]
@@ -15,7 +19,11 @@
   {
    "cell_type": "markdown",
    "id": "promising-steal",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Available functions\n",
     "\n",
@@ -28,7 +36,11 @@
   {
    "cell_type": "markdown",
    "id": "greatest-wholesale",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Usage Example"
    ]
@@ -37,7 +49,11 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "lonely-cigarette",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from draco import run_clingo"
@@ -47,7 +63,11 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "unauthorized-triple",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -71,7 +91,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "toxic-silicon",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": []
   }

--- a/docs/api/schema.ipynb
+++ b/docs/api/schema.ipynb
@@ -2,7 +2,11 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Read Data and Generate the Schema\n",
     "\n",
@@ -11,7 +15,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Available functions\n",
     "\n",
@@ -26,7 +34,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Usage Example"
    ]
@@ -34,7 +46,11 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from draco import schema_from_dataframe, dict_to_facts"
@@ -42,7 +58,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "In this example, we use a weather dataset from Vega datasets but this could be any Pandas dataframe."
    ]
@@ -50,7 +70,11 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from vega_datasets import data\n",
@@ -60,7 +84,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "We can then call `schema_from_dataframe` to get schema information from the pandas dataframe. The schema information is a dictionary."
    ]
@@ -68,7 +96,11 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -125,7 +157,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "We can then convert the schema dictionary into facts that Dracos constraint solver can use with `dict_to_facts`. The function returns a list of facts. The solver will be able to parse these facts and consider them in the recommendation process."
    ]
@@ -133,7 +169,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {

--- a/docs/facts/intro.md
+++ b/docs/facts/intro.md
@@ -4,11 +4,11 @@ To express knowledge about visualizations, we first need a language to describe 
 
 ## Draco has a Generic Specification Format
 
-The constraint solver Clingo reasons about the facts that describe a visualization. The specific format we use to describe facts to the solver is as a _function_ of the name `entity` or `attribute`.
+The constraint solver [Clingo](https://potassco.org/clingo/) reasons about the facts that describe a visualization. The specific format we use to describe facts to the solver is as a _function_ of the name `entity` or `attribute`.
 
 ### Entities
 
-Entities describe objects. The facts `entity` describes what other entities are associates with an entity. If an entity has no parents, we use a special identifier `root`. For example, `entity(view,root,v1).` says that there is a view v1 on the root.
+Entities describe objects. The facts `entity` describes what other entities associate with an entity. If an entity has no parents, we use a special identifier `root`. For example, `entity(view,root,v1).` says that there is a view v1 on the root.
 
 ### Attributes
 

--- a/docs/facts/schema.md
+++ b/docs/facts/schema.md
@@ -4,7 +4,7 @@ In Draco, you can describe what you know about the dataset and the fields in the
 
 Besides general statistics about the whole dataset, the schema has information about field types and field statistics.
 
-You can use Draco's [data schema API](../api/schema.ipynb) to generate a schema description from a file or Pandas dataframe.
+You can use Draco's [data schema API](../api/schema.ipynb) to generate a schema description from a file or [Pandas dataframe](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html).
 
 ## Dataset Properties
 
@@ -15,7 +15,7 @@ General properties of the dataset that are not specific to a field are propertie
 
 ## Field Properties
 
-Draco can use information about the field type and field statistics. Each field entity is associated with a field. The facts therefore have the form of e.g. `attribute((field,type),foo,number).` (read as _the type of the foo field is number_). For each field, there should be a entity fact `entity` that tells Draco that the field exists on the root (e.g. `entity(field,root,foo).`).
+Draco can use information about the field type and field statistics. Each field entity is associated with a field. The facts therefore have the form of e.g. `attribute((field,type),foo,number).` (read as _the type of the foo field is number_). For each field, there should be an entity fact `entity` that tells Draco that the field exists on the root (e.g. `entity(field,root,foo).`).
 
 `(field,name)`
 : The name of the field.

--- a/docs/facts/task.md
+++ b/docs/facts/task.md
@@ -5,7 +5,7 @@ The task that the user tries to complete when looking at a visualization helps D
 ## Task Properties
 
 `task`
-: Type task type. Can be one of `value` and `summary`.
+: The task type. Can be one of `value` and `summary`.
 
 ## Example
 

--- a/docs/guide.ipynb
+++ b/docs/guide.ipynb
@@ -11,12 +11,16 @@
   {
    "cell_type": "markdown",
    "id": "promising-steal",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## How to customize or extend the knowledge base\n",
     "\n",
     "You can design your own description language and use it with Draco or extend the existing language we use here. If you don't know where to start with the constraints, you can first use our [`run_clingo`](https://dig.cmu.edu/draco2/api/run.html#draco.run.run_clingo) and [`programs`](https://dig.cmu.edu/draco2/api/programs.html) API to generate some recommendations. Then, you should be able to find some recommendations that should have been left out, and you can write constraints to reflect them.  \n",
-    "If you write your own despription language, you need to set up the search space in a similar way to [`generate.lp`](https://github.com/cmudig/draco2/blob/main/draco/asp/generate.lp) before trying to generate recommendations.\n",
+    "If you write your own description language, you need to set up the search space in a similar way to [`generate.lp`](https://github.com/cmudig/draco2/blob/main/draco/asp/generate.lp) before trying to generate recommendations.\n",
     "\n",
     "For example, the following snippet shows how to use the `run_clingo` API to generate one recommendation. You can set a different number to look into more results. "
    ]
@@ -97,7 +101,11 @@
   {
    "cell_type": "markdown",
    "id": "8866d38f",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "If you see that there are too many recommendations, you can:\n",
     " * add more hard constraints\n",
@@ -108,7 +116,7 @@
     " * check if some of your constraints are too tight, and move them to soft constraints\n",
     " \n",
     "\n",
-    "If you see no recommendations, you might have made mistakes in the hard constraints. You can allow violations to check what are the common ones by removing the `violation` constriant, which forbids any violations, from the programs. Below is an example: "
+    "If you see no recommendations, you might have made mistakes in the hard constraints. You can allow violations to check what are the common ones by removing the `violation` constraint, which forbids any violations, from the programs. Below is an example:"
    ]
   },
   {

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -5,7 +5,7 @@ In this book, we describe a new version of Draco. Draco was first published in {
 Draco has three parts.
 
 1. A general description language for visualizations as facts. [Learn more about how Draco describes visualizations.](facts/intro.md)
-2. A knowledge base as constraints over facts. This knowledge base describes which visualizations are valid and what visualizations my be preferred.
+2. A knowledge base as constraints over facts. This knowledge base describes which visualizations are valid and what visualizations might be preferred.
 3. An API to use the [Clingo](https://potassco.org/clingo/) solver to apply the knowledge base to visualizations described as a set of facts. [Go to the API docs.](api/intro.md)
 
 The code for Draco is [available as open source on GitHub](https://github.com/cmudig/draco2).

--- a/draco/draco.py
+++ b/draco/draco.py
@@ -121,7 +121,7 @@ class Draco:
             + spec
         )
 
-        # pass the weights as constrant to Clingo
+        # pass the weights as constraint to Clingo
         args = [f"-c {w}={v}" for w, v in self.weights.items()]
 
         return run_clingo(program, models, True, args)

--- a/draco/run.py
+++ b/draco/run.py
@@ -56,7 +56,7 @@ def run_clingo(
     if not isinstance(program, str):
         program = "\n".join(program)
 
-    # single-shot solving is often faster but we cannot change the program
+    # single-shot solving is often faster, but we cannot change the program
     ctl = clingo.Control(["--single-shot"] + arguments if not topK else arguments)
     config: Any = ctl.configuration
 

--- a/draco/tests/test_constraints.py
+++ b/draco/tests/test_constraints.py
@@ -21,7 +21,7 @@ def test_domain_valid():
     assert is_satisfiable(BASE_PROGRAMS + ["attribute(task,root,summary)."])
 
 
-def test_domain_invlid():
+def test_domain_invalid():
     assert not is_satisfiable(BASE_PROGRAMS + ["attribute((mark,type),0,invalid)."])
     assert not is_satisfiable(BASE_PROGRAMS + ["attribute((scale,type),0,invalid)."])
     assert not is_satisfiable(BASE_PROGRAMS + ["attribute((scale,channel),0,invalid)."])

--- a/draco/tests/test_hard.py
+++ b/draco/tests/test_hard.py
@@ -1052,7 +1052,7 @@ def test_bar_tick_continuous_x_y():
     """
     )
 
-    # both x and y are continous, and x is binned
+    # both x and y are continuous, and x is binned
     assert no_violations(
         b.program
         + """
@@ -1076,7 +1076,7 @@ def test_bar_tick_continuous_x_y():
     """
     )
 
-    # both x and y are continous and binned
+    # both x and y are continuous and binned
     assert no_violations(
         b.program
         + """
@@ -1732,7 +1732,7 @@ def test_bar_tick_area_line_without_continuous_x_y():
     """
     )
 
-    # both x and y are continous, and x is binned
+    # both x and y are continuous, and x is binned
     assert no_violations(
         b.program
         + """
@@ -2424,7 +2424,7 @@ def test_stack_with_non_positional_non_agg():
     """
     )
 
-    # cannot use non positional continuous with stack unless it is aggregated.
+    # cannot use non-positional continuous with stack unless it is aggregated.
     assert (
         list_violations(
             p

--- a/draco/tests/test_soft.py
+++ b/draco/tests/test_soft.py
@@ -934,7 +934,7 @@ def test_aggregate_group_by_raw():
         == []
     )
 
-    # aggregate, not raw continous
+    # aggregate, not raw continuous
     assert (
         list_preferences(
             b.program
@@ -951,7 +951,7 @@ def test_aggregate_group_by_raw():
         == []
     )
 
-    # raw continous
+    # raw continuous
     assert (
         list_preferences(
             b.program
@@ -1012,7 +1012,7 @@ def test_aggregate_no_discrete():
         == []
     )
 
-    # aggregate continous
+    # aggregate continuous
     assert (
         list_preferences(
             b.program
@@ -1033,7 +1033,7 @@ def test_aggregate_no_discrete():
         == [("aggregate_no_discrete", "m1")]
     )
 
-    # raw continous
+    # raw continuous
     assert (
         list_preferences(
             b.program
@@ -1206,7 +1206,7 @@ def test_continuous_not_zero():
     entity(mark,v,m1).
     entity(encoding,m1,e1).
     attribute((encoding,channel),e1,x).
-    attribute((encoding,binnning),e1,10).
+    attribute((encoding,binning),e1,10).
 
     entity(scale,v,s1).
     attribute((scale,channel),s1,x).
@@ -1278,7 +1278,7 @@ def test_size_not_zero():
     entity(mark,v,m1).
     entity(encoding,m1,e1).
     attribute((encoding,channel),e1,size).
-    attribute((encoding,binnning),e1,10).
+    attribute((encoding,binning),e1,10).
 
     entity(scale,v,s1).
     attribute((scale,channel),s1,size).
@@ -1318,7 +1318,7 @@ def test_continuous_pos_not_zero():
     entity(mark,v,m1).
     entity(encoding,m1,e1).
     attribute((encoding,channel),e1,x).
-    attribute((encoding,binnning),e1,10).
+    attribute((encoding,binning),e1,10).
 
     entity(scale,v,s1).
     attribute((scale,channel),s1,x).
@@ -1942,12 +1942,12 @@ def test_number_linear():
         list_preferences(
             b.program
             + """
-    attribute((field,type),temperture,number).
-    attribute((field,unique),temperture,111).
+    attribute((field,type),temperature,number).
+    attribute((field,unique),temperature,111).
 
     entity(mark,v,m).
     entity(encoding,m,e1).
-    attribute((encoding,field),e1,temperture).
+    attribute((encoding,field),e1,temperature).
     attribute((encoding,channel),e1,x).
 
     entity(scale,v,s1).
@@ -1963,13 +1963,13 @@ def test_number_linear():
         list_preferences(
             b.program
             + """
-    attribute((field,type),temperture,number).
-    attribute((field,unique),temperture,111).
+    attribute((field,type),temperature,number).
+    attribute((field,unique),temperature,111).
 
     entity(view,root,v).
     entity(mark,v,m).
     entity(encoding,m,e1).
-    attribute((encoding,field),e1,temperture).
+    attribute((encoding,field),e1,temperature).
     attribute((encoding,channel),e1,x).
     attribute((encoding,binning),e1,20).
 
@@ -1986,12 +1986,12 @@ def test_number_linear():
         list_preferences(
             b.program
             + """
-    attribute((field,type),temperture,number).
-    attribute((field,unique),temperture,111).
+    attribute((field,type),temperature,number).
+    attribute((field,unique),temperature,111).
 
     entity(mark,v,m).
     entity(encoding,m,e1).
-    attribute((encoding,field),e1,temperture).
+    attribute((encoding,field),e1,temperature).
     attribute((encoding,channel),e1,x).
 
     entity(scale,v,s1).
@@ -2007,13 +2007,13 @@ def test_number_linear():
         list_preferences(
             b.program
             + """
-    attribute((field,type),temperture,number).
-    attribute((field,unique),temperture,111).
+    attribute((field,type),temperature,number).
+    attribute((field,unique),temperature,111).
 
     entity(view,root,v).
     entity(mark,v,m).
     entity(encoding,m,e1).
-    attribute((encoding,field),e1,temperture).
+    attribute((encoding,field),e1,temperature).
     attribute((encoding,channel),e1,x).
 
     entity(scale,root,s1).
@@ -3533,7 +3533,7 @@ def test_c_d_tick():
     b = soft.blocks["c_d_tick"]
     assert isinstance(b, Block)
 
-    #  only y, discrete y, data size > deiscrete size(1)
+    #  only y, discrete y, data size > discrete size(1)
     assert (
         list_preferences(
             b.program

--- a/draco/weights.py
+++ b/draco/weights.py
@@ -15,7 +15,7 @@ class Weights:
 
     Attributes:
         :assign_program: The weight assigning functions in the program.
-        :weights: The weight constants as a dictionaty.
+        :weights: The weight constants as a dictionary.
     """
 
     assign_program: str


### PR DESCRIPTION
### Goals

- fix various typos in the docs and source files
- add hyperlinks in docs where sensible
- make the docs overall more pleasant to read

### Notes

The [documentation](https://dig.cmu.edu/draco2/api/draco.html) of the `draco.Draco` class is pretty verbose thanks to the automatic default value expansion of Sphinx. I think it would make sense to spawn a new issue for its fix (I would be glad to contribute).  I have two approaches on my mind for the fix:

1. Tap into the Jupyter Book configuration and register a Sphinx function to remove the default value from the expansion, as suggested by [this StackOverflow answer](https://stackoverflow.com/a/69865409/14457639)
2. Create a custom `__repr__` and/or `__str__` in `programs.Program` and `weights.Weights` to have a more compact value representation, returning a summary of the object instead of the stringified fields generated by `dataclass`

What do you think?