### PR TITLE
docs: no default value expansion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,27 +12,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
       - name: Set up Node
         uses: actions/setup-node@v3
-      - name: Install Poetry
-        uses: snok/install-poetry@v1.3
-      - name: Cache Poetry virtualenv
-        uses: actions/cache@v3.0.4
-        id: cache
+      - name: Install poetry
+        run: pipx install poetry
+      - uses: actions/setup-python@v4
         with:
-          path: ~/.virtualenvs
-          key: poetry-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: |
-            poetry-${{ hashFiles('**/poetry.lock') }}
-      - name: Set Poetry config
-        run: |
-          poetry config virtualenvs.in-project false
-          poetry config virtualenvs.path ~/.virtualenvs
-      - name: Install dependencies
-        run: poetry install --no-interaction
-        if: steps.cache.outputs.cache-hit != 'true'
+          python-version: "3.9"
+          cache: 'poetry'
+      - run: poetry install
 
       - name: Run tests
         run: poetry run pytest --cov=./ --cov-report=xml draco

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -35,6 +35,9 @@ sphinx:
   extra_extensions:
     - "sphinx.ext.autodoc"
     - "sphinx_autodoc_typehints"
+  config:
+    # Possible `autodoc` configs: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#configuration
+    autodoc_preserve_defaults: True
 
 bibtex_bibfiles:
   - references.bib

--- a/docs/api/draco.ipynb
+++ b/docs/api/draco.ipynb
@@ -3,7 +3,11 @@
   {
    "cell_type": "markdown",
    "id": "6e2b382c",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Draco Helper Class\n",
     "\n",
@@ -22,14 +26,18 @@
     "## Class Documentation\n",
     "\n",
     "```{eval-rst}\n",
-    ".. autoclass:: draco.Draco()\n",
+    ".. autoclass:: draco.Draco\n",
     "```"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "6ca28067",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Usage Example"
    ]
@@ -38,7 +46,11 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "90fb6a61",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from draco import Draco\n",
@@ -50,7 +62,11 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "223194f8",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "valid_spec = \"\"\"\n",
@@ -76,7 +92,11 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "8192c897",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -97,7 +117,11 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "06e09203",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -118,7 +142,11 @@
    "cell_type": "code",
    "execution_count": 5,
    "id": "0678a09e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "invalid_spec = \"\"\"\n",
@@ -145,7 +173,11 @@
    "cell_type": "code",
    "execution_count": 6,
    "id": "7f8379d6",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -166,7 +198,11 @@
    "cell_type": "code",
    "execution_count": 7,
    "id": "fc008b2a",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -187,7 +223,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a39a62c1",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": []
   }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,33 +4,33 @@
 # re-generate this one.
 ###############################################################################
 author = 'CMU Data Interaction Group'
+autodoc_preserve_defaults = True
 bibtex_bibfiles = ['references.bib']
 comments_config = {'hypothesis': False, 'utterances': False}
-copyright = '2021'
-exclude_patterns = ['**.ipynb_checkpoints', '.DS_Store', 'Thumbs.db', '_build']
+copyright = '2022'
+exclude_patterns = ['logo-dark.png', 'bibliography.md', 'references.bib', 'conf.py', 'intro.md', '__pycache__', '_toc.yml', 'guide.ipynb', 'applications', 'api', 'facts', 'logo-light.png', 'applications/recommendation.ipynb', 'applications/draco_learn.ipynb', 'applications/data', 'applications/data/kim2018_draco2.json', 'api/run.ipynb', 'api/draco.ipynb', 'api/programs.md', 'api/facts.ipynb', 'api/intro.md', 'api/schema.ipynb', 'facts/tick.png', 'facts/hist.png', 'facts/tick_log.png', 'facts/stack_normalize.png', 'facts/view.md', 'facts/bubble.png', 'facts/scale.md', 'facts/facet_bin.png', 'facts/schema.md', 'facts/intro.md', 'facts/binned_hist.png', 'facts/facet.md', 'facts/encoding.md', 'facts/scatter_color.png', 'facts/examples.ipynb', 'facts/mark.md', 'facts/stack.png', 'facts/facet.png', 'facts/task.md', 'facts/scatter.png', 'facts/bar.png', '_build', 'Thumbs.db', '.DS_Store', '**.ipynb_checkpoints']
 execution_allow_errors = False
 execution_excludepatterns = []
 execution_in_temp = False
 execution_timeout = 30
-extensions = ['sphinx_togglebutton', 'sphinx_copybutton', 'myst_nb', 'jupyter_book', 'sphinx_thebe', 'sphinx_comments', 'sphinx_external_toc', 'sphinx.ext.intersphinx', 'sphinx_panels', 'sphinx_book_theme', 'sphinx.ext.autodoc', 'sphinx_autodoc_typehints', 'sphinxcontrib.bibtex', 'sphinx_jupyterbook_latex']
+extensions = ['sphinx_togglebutton', 'sphinx_copybutton', 'myst_nb', 'jupyter_book', 'sphinx_thebe', 'sphinx_comments', 'sphinx_external_toc', 'sphinx.ext.intersphinx', 'sphinx_design', 'sphinx_book_theme', 'sphinx.ext.autodoc', 'sphinx_autodoc_typehints', 'sphinxcontrib.bibtex', 'sphinx_jupyterbook_latex']
 external_toc_exclude_missing = False
-external_toc_path = '_toc.yml'
 html_baseurl = ''
 html_favicon = ''
 html_logo = 'logo-light.png'
 html_sourcelink_suffix = ''
 html_theme = 'sphinx_book_theme'
-html_theme_options = {'search_bar_text': 'Search this book...', 'launch_buttons': {'notebook_interface': 'jupyterlab', 'binderhub_url': 'https://mybinder.org', 'jupyterhub_url': '', 'thebe': False, 'colab_url': ''}, 'path_to_docs': 'docs', 'repository_url': 'https://github.com/cmudig/draco2', 'repository_branch': 'main', 'google_analytics_id': '', 'extra_navbar': 'Powered by <a href="https://jupyterbook.org">Jupyter Book</a>', 'extra_footer': '', 'home_page_in_toc': True, 'use_repository_button': True, 'use_edit_page_button': True, 'use_issues_button': True}
+html_theme_options = {'search_bar_text': 'Search this book...', 'launch_buttons': {'notebook_interface': 'jupyterlab', 'binderhub_url': 'https://mybinder.org', 'jupyterhub_url': '', 'thebe': False, 'colab_url': ''}, 'path_to_docs': 'docs', 'repository_url': 'https://github.com/cmudig/draco2', 'repository_branch': 'main', 'google_analytics_id': '', 'extra_navbar': 'Powered by <a href="https://jupyterbook.org">Jupyter Book</a>', 'extra_footer': '', 'home_page_in_toc': True, 'announcement': '', 'use_repository_button': True, 'use_edit_page_button': True, 'use_issues_button': True, 'single_page': True}
 html_title = 'Draco'
 jupyter_cache = ''
 jupyter_execute_notebooks = 'auto'
 language = None
 latex_engine = 'pdflatex'
+master_doc = '_config'
 myst_enable_extensions = ['linkify', 'substitution']
 myst_url_schemes = ['mailto', 'http', 'https']
 nb_output_stderr = 'show'
 numfig = True
-panels_add_bootstrap_css = False
 pygments_style = 'sphinx'
 suppress_warnings = ['myst.domains']
 use_jupyterbook_latex = True


### PR DESCRIPTION
### Goals

- Disable the expansion of default values in docstrings
- Fix the looks of the [Draco Class Documentation section](https://dig.cmu.edu/draco2/api/draco.html#class-documentation)

![_Users_petergy_Coding_OpenSourceProjects_draco2_docs__build_html_api_draco html](https://user-images.githubusercontent.com/40776291/179939270-74451bda-0142-4da7-a69b-8fd6156196a6.png)

### Notes

 - Found a solution which is the cleanest one imho: there is an [official `autodoc` config](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_preserve_defaults) for this