### PR TITLE
docs: generate method docs of `draco.Draco`

### DIFF
--- a/docs/api/draco.ipynb
+++ b/docs/api/draco.ipynb
@@ -27,6 +27,7 @@
     "\n",
     "```{eval-rst}\n",
     ".. autoclass:: draco.Draco\n",
+    "    :members:\n",
     "```"
    ]
   },


### PR DESCRIPTION
### Goals

- generate documentation for the methods of the `draco.Draco` class

### Notes

- Spawned by #343
- using the `:members:` option with the `autoclass::` directive, as documented in the [official docs](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#directive-option-automodule-members)

![_Users_petergy_Coding_OpenSourceProjects_draco2_docs__build_html_api_draco html (1)](https://user-images.githubusercontent.com/40776291/180069124-45ec2edf-9392-44b6-8fb4-fdee864d7473.png)