### PR TITLE
build: uniform `poetry` installation and caching across gh-actions

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -11,27 +11,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Install poetry
+        run: pipx install poetry
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.9
-      - name: Install Poetry
-        uses: snok/install-poetry@v1.3
-      - name: Cache Poetry virtualenv
-        uses: actions/cache@v3.0.4
-        id: cache
-        with:
-          path: ~/.virtualenvs
-          key: poetry-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: |
-            poetry-${{ hashFiles('**/poetry.lock') }}
-      - name: Set Poetry config
-        run: |
-          poetry config virtualenvs.in-project false
-          poetry config virtualenvs.path ~/.virtualenvs
-      - name: Install dependencies
-        run: poetry install --no-interaction
-        if: steps.cache.outputs.cache-hit != 'true'
+          python-version: "3.9"
+          cache: 'poetry'
+      - run: poetry install
 
       - name: Make book
         run: make book


### PR DESCRIPTION
### Goals

- handle the installation and caching of `poetry` in `book.yml` in the same way as in `test.yml` (introduced in #343)

### Notes

- might prevent the build issue faced in f294f41
- achieving the same thing across GitHub-Actions in the same way would be sensible