### PR TITLE
docs: fix typos in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 **Work in Progress**
 
-Draco is a formal framework for representing design knowledge about effective visualization design as a collection of constraints. You can use Draco to find effective visualization visual designs or validate visualization designs. Draco's constraints are implemented in based on Answer Set Programming (ASP) and solved with the Clingo constraint solver. We also implemented a way to learn weights for the recommendation system directly from the results of graphical perception experiment. Draco v2 is a much imprived version of the first iteration of [Draco](https://github.com/uwdata/draco).
+Draco is a formal framework for representing design knowledge about effective visualization design as a collection of constraints. You can use Draco to find effective visualization visual designs or validate visualization designs. Draco's constraints are based on Answer Set Programming (ASP) and solved with the [Clingo](https://github.com/potassco/clingo) constraint solver. We also implemented a way to learn weights for the recommendation system directly from the results of graphical perception experiment. Draco v2 is a much improved version of the first iteration of [Draco](https://github.com/uwdata/draco).
 
 ## Documentation
 


### PR DESCRIPTION
### Goals

Fixes typos and adds a hyperlink to Clingo in `README.md`.