### PR TITLE
fix: binder requirements (#430)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+# General Python Cache
+__pycache__
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# pytest
+.pytest_cache
+
+# Pyre type checker
+.pyre/
+
+# Pytype type checker
+.pytype
+
+# temporary files
+**/_tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,13 @@ RUN python -m pip install --upgrade pip &&  \
 COPY pyproject.toml poetry.lock ./
 # Purposely not using --no-dev here to install dev dependencies needed for Jupyter Notebooks
 RUN poetry config virtualenvs.create false && \
-    poetry install && \
-    pip install git+https://github.com/cmudig/draco2.git#egg=draco  # Install Draco2 from git, needed for notebooks
+    poetry install
 
 # Copy the project source code
 COPY . .
+
+# Install Draco2 from local sources, needed for notebooks
+RUN pip install -e .
 
 # Grant permissions to the notebook user
 RUN chown -R ${NB_USER} ${HOME}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN adduser --disabled-password \
     --gecos "Default user" \
     --uid ${NB_UID} \
     ${NB_USER}
-WORKDIR ${HOME}
+WORKDIR ${HOME}/app
 
 # Install dependencies using Poetry
 RUN python -m pip install --upgrade pip &&  \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.10.8-buster
+WORKDIR /usr/src/app
+
+# Make /tmp writable, needed for Jupyter Notebooks
+ENV HOME=/tmp
+
+# Install dependencies using Poetry
+RUN python -m pip install --upgrade pip &&  \
+    pip install poetry
+COPY pyproject.toml poetry.lock ./
+# Purposely not using --no-dev here to install dev dependencies needed for Jupyter Notebooks
+RUN poetry config virtualenvs.create false && \
+    poetry install && \
+    pip install git+https://github.com/cmudig/draco2.git#egg=draco  # Install Draco2 from git, needed for notebooks
+
+# Copy the project source code
+COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,16 @@
 FROM python:3.10.8-buster
-WORKDIR /usr/src/app
 
-# Make /tmp writable, needed for Jupyter Notebooks
-ENV HOME=/tmp
+# Create user with a home directory
+ARG NB_USER="draco2"
+ARG NB_UID="1000"
+ENV USER ${NB_USER}
+ENV HOME /home/${NB_USER}
+
+RUN adduser --disabled-password \
+    --gecos "Default user" \
+    --uid ${NB_UID} \
+    ${NB_USER}
+WORKDIR ${HOME}
 
 # Install dependencies using Poetry
 RUN python -m pip install --upgrade pip &&  \
@@ -15,3 +23,7 @@ RUN poetry config virtualenvs.create false && \
 
 # Copy the project source code
 COPY . .
+
+# Grant permissions to the notebook user
+RUN chown -R ${NB_USER} ${HOME}
+USER ${NB_USER}


### PR DESCRIPTION
### Goals

- Fix missing Binder modules

### Notes

While Binder supports [various simpler configuration files](https://mybinder.readthedocs.io/en/latest/using/config_files.html), using a `Dockerfile` has the most benefits for us IMHO.

- If we wanted to use a `requirements.txt` we would need to constantly sync between `pyproject.toml` and `requirements.txt` using `poetry export`. While this would be possible using a GH action, it would have been more work than the committed `Dockerfile`
- Using any of the other config options would not fit into our Poetry setup
- With the custom Docker env I declared, opening the terminal in Binder's Jupyter Lab will give access to the same dev environment we are using. That is, executing `make` targets is also possible.

I had to add Draco 2 as a pip package to the Docker environment, otherwise, the notebooks complain about it as a missing dependency.

You can preview this branch in Binder using the following link: [https://mybinder.org/v2/gh/cmudig/draco2/fix/430-binder-requirements](https://mybinder.org/v2/gh/cmudig/draco2/fix/430-binder-requirements)

closes #430