### PR TITLE
ci: test `Dockerfile` (#483)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Build docker image
         run: docker build -t draco .
 
-      - name: Run `make all`
-        run: docker run --rm draco bash -c "make all"
+      - name: Run all make targets
+        run: docker run --rm draco bash -c "make"
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Build docker image
         run: docker build -t draco .
 
-      - name: Run `make test`
+      - name: Run `make all`
         run: docker run --rm draco bash -c "make all"
 
   lint:
@@ -64,6 +64,7 @@ jobs:
   automerge:
     needs:
       - test
+      - test-docker
       - lint
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,17 @@ jobs:
         with:
           fail_ci_if_error: true
 
+  test-docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build docker image
+        run: docker build -t draco .
+
+      - name: Run `make test`
+        run: docker run --rm draco bash -c "make all"
+
   lint:
     runs-on: ubuntu-latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.10.9-buster
 
+# Logging to the console breaks without this
+ENV PYTHONUNBUFFERED 1
+ENV PYTHONFAULTHANDLER 1
+
 # Install Node.js as it is needed as a dev dependency
 RUN apt-get update && apt-get install -y \
     curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-FROM python:3.10.9-buster
-
-# Logging to the console breaks without this
-ENV PYTHONUNBUFFERED 1
-ENV PYTHONFAULTHANDLER 1
+FROM python:3.10.9-bullseye
 
 # Install Node.js as it is needed as a dev dependency
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,15 @@
 FROM python:3.10.9-buster
 
+# Install Node.js as it is needed as a dev dependency
+RUN apt-get update && apt-get install -y \
+    curl \
+    gnupg \
+    ca-certificates \
+    lsb-release &&  \
+    curl -fsSL https://deb.nodesource.com/setup_18.x | bash - &&  \
+    apt-get install -y nodejs && \
+    npm install -g npm@latest
+
 # Create user with a home directory
 ARG NB_USER="draco2"
 ARG NB_UID="1000"

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ grounding-size: ./draco/asp/examples/*
 	@echo "==> ⏚ Size of grounded program"
 	@for file in $^ ; do \
 		echo $${file} ; \
-		poetry run clingo draco/asp/generate.lp draco/asp/define.lp draco/asp/helpers.lp draco/asp/hard.lp $${file} --text | wc -l ; \
+		poetry run python -m clingo draco/asp/generate.lp draco/asp/define.lp draco/asp/helpers.lp draco/asp/hard.lp $${file} --text | wc -l ; \
 	done
 
 .PHONY: publish


### PR DESCRIPTION
The `test-docker` job I added in this PR executes `make all` inside a docker container based on our root `Dockerfile`. If the `test-docker` job succeeds along with the other, non-dockerized checks, we can conclude that the dockerized environment works as expected.

The job is expected to fail if any of the other jobs (`lint` or `test`) fail.

I had to update from debian buster to bullseye, since I kept getting a Python seg fault inside the container running on the GH runner. The error disappeared after upgrading to bullseye.

Closes #483