### PR TITLE
fix: use `poetry install --with web` to build docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,7 +190,7 @@ jobs:
           cache: "poetry"
 
       - name: Install dependencies
-        run: poetry install
+        run: poetry install --with web
 
       - name: Make book
         run: make book


### PR DESCRIPTION
We specify the JupyterLite deps in that group.