### PR TITLE
ci: use artifacts for gh pages build (#522)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,6 +176,16 @@ jobs:
       PYODIDE_DISTRO_NAME: ${{ needs.variables.outputs.pyodide_distro_name }}
       PYODIDE_DISTRO_URL: ${{ needs.variables.outputs.pyodide_distro_url }}
 
+    environment:
+      name: github-pages
+      url: ${{ steps.gh_pages_deployment.outputs.page_url }}
+
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -227,11 +237,17 @@ jobs:
       - name: Display HTML bundle tree
         run: find docs/_build/html/ | sed -e "s/[^-][^\/]*\// |/g" -e "s/|\([^ ]\)/|-\1/"
 
-      - name: Upload Documentation site to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Upload Documentation Site Artifact
+        uses: actions/upload-pages-artifact@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/_build/html
+          path: ./docs/_build/html
+
+      - name: Deploy to GitHub Pages
+        id: gh_pages_deployment
+        uses: actions/deploy-pages@v1
 
   pin_distro:
     if: ${{ needs.variables.outputs.is_release == 'true' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,6 +176,7 @@ jobs:
       PYODIDE_DISTRO_NAME: ${{ needs.variables.outputs.pyodide_distro_name }}
       PYODIDE_DISTRO_URL: ${{ needs.variables.outputs.pyodide_distro_url }}
 
+    # This job is responsible for the GH Pages deployment
     environment:
       name: github-pages
       url: ${{ steps.gh_pages_deployment.outputs.page_url }}


### PR DESCRIPTION
The implementation builds on top of the [Deploy Static HTML](https://github.com/cmudig/draco2/new/main?filename=.github%2Fworkflows%2Fstatic.yml) example action.

I could not run the action on this branch, since protection rules seem to allow gh pages deployment only through the `main` branch.

