### PR TITLE
chore: set Pyodide version to `0.22.1`

### DIFF
--- a/pyodide/build.py
+++ b/pyodide/build.py
@@ -17,7 +17,7 @@ PYODIDE_REQUIREMENTS_PATH = PYODIDE_PACKAGES_PATH / "pyodide-requirements.txt"
 PYODIDE_REPO_NAME = "pyodide-src"
 PYODIDE_REPO_PATH = PYODIDE_BUILD_MODULE_ROOT_PATH / PYODIDE_REPO_NAME
 PYODIDE_REPO_URL = "https://github.com/pyodide/pyodide.git"
-PYODIDE_REPO_TAG = "0.23.3"
+PYODIDE_REPO_TAG = "0.22.1"
 
 # Directory where the Pyodide distribution will be built
 PYODIDE_DIST_PATH = PYODIDE_REPO_PATH / "dist"


### PR DESCRIPTION
Needed so that the repo Python version and the web Python version are in sync. To be reverted as soon as google/pytype#1308 is addressed and we can bump our repo Python version to `3.11`.