### PR TITLE
ci: install `clingo` for `jupyter-book` build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,9 +207,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
 
-      # Installing system dependencies to run each notebook
-      - name: Install native dependencies
-        run: apt-get update && apt-get install -y gringo
+      # Installing system dependencies required by notebooks to be executed
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y gringo
 
       - name: Make book
         run: make book

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,6 +207,10 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
 
+      # Installing system dependencies to run each notebook
+      - name: Install native dependencies
+        run: apt-get update && apt-get install -y gringo
+
       - name: Make book
         run: make book
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,6 +6,11 @@ author: CMU Data Interaction Group
 copyright: "2023"
 logo: logo-light.png
 
+execute:
+  allow_errors: true
+  stderr_output: remove
+  timeout: 300
+
 # Define the name of the latex output file for PDF builds
 latex:
   latex_documents:

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,11 +6,6 @@ author: CMU Data Interaction Group
 copyright: "2023"
 logo: logo-light.png
 
-execute:
-  allow_errors: true
-  stderr_output: remove
-  timeout: 300
-
 # Define the name of the latex output file for PDF builds
 latex:
   latex_documents:
@@ -47,6 +42,8 @@ sphinx:
   config:
     # Possible `autodoc` configs: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#configuration
     autodoc_preserve_defaults: True
+    # Print tracebacks for execution errors directly into the terminal, useful in CI (https://jupyterbook.org/en/stable/content/execute.html#execution-tracebacks-in-the-terminal)
+    nb_execution_show_tb: True
 
 bibtex_bibfiles:
   - references.bib


### PR DESCRIPTION
Should fix this issue we have in the current docs:

<img width="843" alt="Screenshot 2023-08-02 at 05 01 46" src="https://github.com/cmudig/draco2/assets/40776291/99777bde-fc44-415f-8dfd-679583c507c0">
