### PR TITLE
ci: adjust Pyodide deps and retrieve prebuilt artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ pyodide-build: pyodide-prepare
 .PHONY: jupyterlite-build
 jupyterlite-build:
 	@echo "==> 💡 Building Jupyter Lite Static Site"
-	@cd jupyterlite && poetry run python build.py && poetry run jupyter lite build
+	@cd jupyterlite && rm -rf lite-dir/static/pyodide && poetry run python build.py && poetry run jupyter lite build
 
 
 # Re-using the Jupyter Lite build target, since it handles the download and 'caching' of our Pyodide distribution.

--- a/poetry.lock
+++ b/poetry.lock
@@ -4811,4 +4811,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10.0,<3.12"
-content-hash = "11d187404808fee6b4dadd46824044e84e4aad31791a0a451ea10d05fa60583e"
+content-hash = "f542273d2ff937b4c441fa0a17d783dd873d58f8bb0cd24f7216acffe4f22df0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4811,4 +4811,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10.0,<3.12"
-content-hash = "f542273d2ff937b4c441fa0a17d783dd873d58f8bb0cd24f7216acffe4f22df0"
+content-hash = "ca8833c564da7b5135c294bd060c12dd141cadaf944d4a8ba89c9c1ad3b0e618"

--- a/pyodide/build.py
+++ b/pyodide/build.py
@@ -265,11 +265,22 @@ def load_pyodide_requirements(
 def create_distro_build_script(pyodide_requirements: list) -> None:
     packages_to_install = [*pyodide_requirements, "draco"]
     recipe_installation_cmds = [install_recipe_cmd(p) for p in packages_to_install]
+
+    # We need additional components to build `pydantic-core` properly,
+    # as it is written in Rust
+    pydantic_core_buildenv = [
+        "pip install maturin",
+        "rustup install nightly",
+        "rustup default nightly",
+        "rustup target add wasm32-unknown-emscripten",
+    ]
+
     script_body = "\n".join(
         [
             "#!/bin/bash",
             "python -m pip install --upgrade pip",
             "pip install -e pyodide-build",
+            *pydantic_core_buildenv,
             "make",
             *recipe_installation_cmds,
         ]

--- a/pyodide/cache_dl.py
+++ b/pyodide/cache_dl.py
@@ -1,0 +1,162 @@
+"""
+Given a base URL to a hosted Pyodide distribution, we compare its `pyodide-lock.json`
+with the local `pyodide/packages/*`.
+
+If the remote lockfile includes a package of the same version
+as the local recipe specifies, we download the remote artifacts
+instead of building them locally from source.
+
+If the local and remote Pyodide versions do not match, we build everything from source.
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import TypedDict
+
+import requests
+import yaml
+
+
+def warn(msg: str) -> None:
+    """
+    Prints a warning message to stderr.
+
+    :param msg: the warning message to print
+    """
+    WARN_COLOR = "\033[93m"
+    ENDC = "\033[0m"
+    print(f"{WARN_COLOR}Warning: {msg}{ENDC}", file=sys.stderr)
+
+
+def info(msg: str) -> None:
+    """
+    Prints an info message to stdout.
+
+    :param msg: the info message to print
+    """
+    INFO_COLOR = "\033[94m"
+    ENDC = "\033[0m"
+    print(f"{INFO_COLOR}Info: {msg}{ENDC}")
+
+
+class LockfileInfo(TypedDict):
+    arch: str
+    platform: str
+    version: str
+    python: str
+
+
+class LockfilePackage(TypedDict):
+    name: str
+    version: str
+    file_name: str
+
+
+class Lockfile(TypedDict):
+    info: LockfileInfo
+    packages: dict[str, LockfilePackage]
+
+
+class RecipePackage(TypedDict):
+    name: str
+    version: str
+
+
+class Recipe(TypedDict):
+    package: RecipePackage
+
+
+def get_recipe_path(package_name: str) -> Path:
+    return Path(__file__).parent / "packages" / package_name / "meta.yaml"
+
+
+def load_recipe(package_name: str) -> Recipe | None:
+    path = get_recipe_path(package_name)
+    try:
+        return yaml.safe_load(open(path))
+    except FileNotFoundError:
+        return None
+
+
+def load_lockfile(lockfile_url: str) -> Lockfile | None:
+    res = requests.get(lockfile_url)
+    if res.status_code == 200:
+        return json.loads(res.text)
+
+    return None
+
+
+def load_remote_artifact(url: str, name: str) -> bytes | None:
+    url = f"{url}/{name}"
+    res = requests.get(url)
+    if res.status_code == 200:
+        return res.content
+
+    return None
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Download prebuilt Pyodide artifacts")
+    parser.add_argument(
+        "--url",
+        default="https://dig.cmu.edu/draco2/jupyterlite/static/pyodide",
+        help="Base URL to a hosted Pyodide distribution",
+    )
+    parser.add_argument("--tag", default="0.24.1", help="Pyodide version tag")
+
+    args = parser.parse_args()
+    pyodide_url = args.url
+    pyodide_tag = args.tag
+
+    lockfile_url = f"{pyodide_url}/pyodide-lock.json"
+    info(f"⬇️ Downloading lockfile from {lockfile_url}")
+    lockfile = load_lockfile(lockfile_url)
+
+    if lockfile is None:
+        warn("🚧 Lockfile not found. Building everything from source.")
+        sys.exit(0)
+
+    if lockfile["info"]["version"] != pyodide_tag:
+        warn(
+            "🚧 Pyodide version mismatch "
+            f'(local: {pyodide_tag}, remote: {lockfile["info"]["version"]}). '
+            "Will build everything from source."
+        )
+        sys.exit(0)
+
+    for package in lockfile["packages"].values():
+        package_name = package["name"].replace("-tests", "")
+        recipe = load_recipe(package_name)
+        if recipe is None:
+            warn(f"🚧 Recipe not found for {package['name']}. Will build from source.")
+            continue
+
+        remote_version = str(package["version"]).lower().strip()
+        local_version = str(recipe["package"]["version"]).lower().strip()
+        if remote_version != local_version:
+            warn(
+                f"🚧 {package['name']} version mismatch "
+                f"(local: {local_version}, remote: {remote_version}). "
+                "Will build from source."
+            )
+            continue
+
+        info(f"⬇️ Downloading {package['file_name']}")
+        content = load_remote_artifact(pyodide_url, package["file_name"])
+        if content is None:
+            warn(
+                f"🚧 Failed to download {package['file_name']}. "
+                "Will build from source."
+            )
+            continue
+
+        dist_folder = get_recipe_path(package_name).parent / "dist"
+        dist_folder.mkdir(parents=True, exist_ok=True)
+        info(f"📦 Saving {package['file_name']} to {dist_folder}")
+        dist_folder.joinpath(package["file_name"]).write_bytes(content)
+
+        build_folder = get_recipe_path(package_name).parent / "build"
+        build_folder.mkdir(parents=True, exist_ok=True)
+        info(f"📦 Marking package as built in {build_folder}")
+        (build_folder / ".packaged").write_text("\n")

--- a/pyodide/packages/annotated-types/meta.yaml
+++ b/pyodide/packages/annotated-types/meta.yaml
@@ -1,0 +1,13 @@
+package:
+  name: annotated-types
+  version: 0.6.0
+  top-level:
+    - annotated_types
+source:
+  url: https://files.pythonhosted.org/packages/67/fe/8c7b275824c6d2cd17c93ee85d0ee81c090285b6d52f4876ccc47cf9c3c4/annotated_types-0.6.0.tar.gz
+  sha256: 563339e807e53ffd9c267e99fc6d9ea23eb8443c08f112651963e24e22f84a5d
+about:
+  home: https://github.com/annotated-types/annotated-types
+  PyPI: https://pypi.org/project/annotated-types/
+  summary: "Reusable constraint types to use with typing.Annotated"
+  license: MIT

--- a/pyodide/packages/pydantic-core/meta.yaml
+++ b/pyodide/packages/pydantic-core/meta.yaml
@@ -1,0 +1,16 @@
+package:
+  name: pydantic-core
+  version: 2.11.0
+  top-level:
+    - pydantic_core
+source:
+  url: https://files.pythonhosted.org/packages/4b/f8/c074b0bf58166b803ce23a18b33be12b04930d590278eccbb262aa92ca38/pydantic_core-2.11.0.tar.gz
+  sha256: 55c6d7fdc94a98e0551870774e27be1ec5cd847230015463853d27a73b05ba13
+requirements:
+  run:
+    - typing-extensions
+about:
+  home: https://github.com/pydantic/pydantic-core
+  PyPI: https://pypi.org/project/pydantic-core
+  summary: This package provides the core functionality for pydantic validation and serialization.
+  license: MIT

--- a/pyodide/packages/pydantic/meta.yaml
+++ b/pyodide/packages/pydantic/meta.yaml
@@ -9,6 +9,7 @@ source:
 requirements:
   run:
     - typing-extensions
+    - pydantic-core
 about:
   home: https://github.com/samuelcolvin/pydantic
   PyPI: https://pypi.org/project/pydantic

--- a/pyodide/packages/pydantic/meta.yaml
+++ b/pyodide/packages/pydantic/meta.yaml
@@ -8,8 +8,9 @@ source:
   url: https://files.pythonhosted.org/packages/df/e8/4f94ebd6972eff3babcea695d9634a4d60bea63955b9a4a413ec2fd3dd41/pydantic-2.4.2.tar.gz
 requirements:
   run:
-    - typing-extensions
+    - annotated-types
     - pydantic-core
+    - typing-extensions
 about:
   home: https://github.com/samuelcolvin/pydantic
   PyPI: https://pypi.org/project/pydantic

--- a/pyodide/packages/pydantic/meta.yaml
+++ b/pyodide/packages/pydantic/meta.yaml
@@ -1,0 +1,16 @@
+package:
+  name: pydantic
+  version: 2.4.2
+  top-level:
+    - pydantic
+source:
+  sha256: 94f336138093a5d7f426aac732dcfe7ab4eb4da243c88f891d65deb4a2556ee7
+  url: https://files.pythonhosted.org/packages/df/e8/4f94ebd6972eff3babcea695d9634a4d60bea63955b9a4a413ec2fd3dd41/pydantic-2.4.2.tar.gz
+requirements:
+  run:
+    - typing-extensions
+about:
+  home: https://github.com/samuelcolvin/pydantic
+  PyPI: https://pypi.org/project/pydantic
+  summary: Data validation and settings management using python type hints
+  license: MIT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ python = ">=3.10.0,<3.12"
 scikit-learn = "^1.2.1"
 uvicorn = ">=0.18.3,<0.24.0"
 tabulate = "^0.9.0"
+pyyaml = "^6.0.1"
 
 [tool.poetry.group.dev.dependencies]
 black = { extras = ["jupyter"], version = "^23.1.0" }
@@ -75,6 +76,7 @@ optional = true
 [tool.poetry.group.web.dependencies]
 jupyterlite = "^0.1.3"
 libarchive-c = ">=4,<6"
+pyyaml = "^6.0.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ python = ">=3.10.0,<3.12"
 scikit-learn = "^1.2.1"
 uvicorn = ">=0.18.3,<0.24.0"
 tabulate = "^0.9.0"
-pyyaml = "^6.0.1"
 
 [tool.poetry.group.dev.dependencies]
 black = { extras = ["jupyter"], version = "^23.1.0" }


### PR DESCRIPTION
**⚠️ The renderer cannot be used via JupyterLite at the moment, meaning that no actual visuals can be displayed when getting started with Draco through the browser. This PR adds a fix.**

<img width="2112" alt="Screenshot 2023-10-22 at 15 27 24" src="https://github.com/cmudig/draco2/assets/40776291/aa9fa31a-4168-45e4-9e62-6507dad329d7">

### Dependency Adjustments

This is caused by a regression introduced in #673 after we migrated to Pydantic 2: we migrated the pure-python project dependency, but not the Pyodide dependency.

We should add some tests around our WASM distribution soon.

To support Pydantic 2 in Pyodide I had to add Rust as a dependency to the Pyodide build environment, as https://github.com/pydantic/pydantic-core is written in Rust.

### Using prebuilt artifacts in CI

Our latest Pyodide distribution is always hosted under https://dig.cmu.edu/draco2/jupyterlite/static/pyodide. Instead of rebuilding each artifact each time, we can do a diffing based on 

- the version of the latest, already-built artifact and
- the version of the package specified in the local `meta.yaml` Pyodide recipe files

This simple idea is implemented in `pyodide/cache_dl.py`.

### Post-PR Results

<img width="2112" alt="Screenshot 2023-10-22 at 16 27 37" src="https://github.com/cmudig/draco2/assets/40776291/832b6734-775c-4829-b274-6c07925974b8">