### PR TITLE
chore: update `jupyterlite` and explicitly list Pyodide kernel

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1735,24 +1735,23 @@ files = [
 
 [[package]]
 name = "jupyterlite"
-version = "0.2.3"
+version = "0.3.0"
 description = ""
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jupyterlite-0.2.3-py3-none-any.whl", hash = "sha256:b5e7cc43c79f53b3c0a66f24baeef4330418f11dcf7d0ae8427961483cd429ae"},
-    {file = "jupyterlite-0.2.3.tar.gz", hash = "sha256:20dcbfd9e1f850c96ffa46a5f3f98116e481d0be198fc482491c15d5411fe510"},
+    {file = "jupyterlite-0.3.0-py3-none-any.whl", hash = "sha256:f011943bf945f415bc4edbfb8f51ced74a82835520be1ecc973afa47936dc3f0"},
+    {file = "jupyterlite-0.3.0.tar.gz", hash = "sha256:824c9a6dad850766ececf4863052b944543b0650fe1be8c7a99d9df0150a5c60"},
 ]
 
 [package.dependencies]
-jupyterlite-core = ">=0.2.3"
-jupyterlite-javascript-kernel = "*"
+jupyterlite-core = ">=0.3.0"
 
 [package.extras]
-all = ["jsonschema (>=3)", "jupyter-server", "jupyterlab (>=4.0.11,<5.0)", "jupyterlab-server (>=2.8.1,<3)", "libarchive-c (>=4.0)", "notebook (>=7.0.7,<8.0)", "pkginfo", "tornado (>=6.1)"]
+all = ["jsonschema (>=3)", "jupyter-server", "jupyterlab (>=4.1.1,<4.2)", "jupyterlab-server (>=2.8.1,<3)", "libarchive-c (>=4.0)", "notebook (>=7.1.0,<7.2)", "pkginfo", "tornado (>=6.1)"]
 check = ["jsonschema[format-nongpl] (>=3)"]
 contents = ["jupyter-server"]
-lab = ["jupyterlab (>=4.0.11,<5.0)", "notebook (>=7.0.7,<8.0)"]
+lab = ["jupyterlab (>=4.1.0,<4.2)", "notebook (>=7.1.0,<7.2)"]
 libarchive = ["libarchive-c (>=4.0)"]
 serve = ["tornado (>=6.1)"]
 translation = ["jupyterlab-server (>=2.8.1,<3)"]
@@ -1783,15 +1782,25 @@ test = ["ansi2html", "diffoscope", "pytest-console-scripts", "pytest-cov", "pyte
 translation = ["jupyterlab-server (>=2.8.1,<3)"]
 
 [[package]]
-name = "jupyterlite-javascript-kernel"
-version = "0.3.0"
-description = "A JavaScript kernel for JupyterLite"
+name = "jupyterlite-pyodide-kernel"
+version = "0.3.1"
+description = "Python kernel for JupyterLite powered by Pyodide"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jupyterlite_javascript_kernel-0.3.0-py3-none-any.whl", hash = "sha256:7753c172d3c8bd50d7e7c05d1b667c3fa5566f90d38bf1bdd160f9752e1746b7"},
-    {file = "jupyterlite_javascript_kernel-0.3.0.tar.gz", hash = "sha256:39870efb4cdfe669b99552b4ad21a82f575691e4fdaf77b33bef04ec230889ff"},
+    {file = "jupyterlite_pyodide_kernel-0.3.1-py3-none-any.whl", hash = "sha256:ac9d9dd95adcced57d465a7b298f220d8785845c017ad3abf2a3677ff02631c6"},
+    {file = "jupyterlite_pyodide_kernel-0.3.1.tar.gz", hash = "sha256:cff663cfed4e6319bd3256f09e02d450f94917ba3704d9178d69146bb3467801"},
 ]
+
+[package.dependencies]
+jupyterlite-core = ">=0.3.0,<0.4.0"
+pkginfo = "*"
+
+[package.extras]
+dev = ["build", "hatch", "jupyterlab (>=4.0.7,<4.1.0a0)"]
+docs = ["ipywidgets (>=8.1.2,<9)", "jupyter-server-mathjax", "jupyterlab-language-pack-fr-fr", "jupyterlab-language-pack-zh-cn", "libarchive-c", "myst-parser", "pydata-sphinx-theme", "sphinx-copybutton"]
+lint = ["ruff (>=0.3.0)"]
+test = ["pytest", "pytest-console-scripts (>=1.4.0)", "pytest-cov", "pytest-html"]
 
 [[package]]
 name = "kiwisolver"
@@ -2808,6 +2817,20 @@ mic = ["olefile"]
 tests = ["check-manifest", "coverage", "defusedxml", "markdown2", "olefile", "packaging", "pyroma", "pytest", "pytest-cov", "pytest-timeout"]
 typing = ["typing-extensions"]
 xmp = ["defusedxml"]
+
+[[package]]
+name = "pkginfo"
+version = "1.10.0"
+description = "Query metadata from sdists / bdists / installed packages."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "pkginfo-1.10.0-py3-none-any.whl", hash = "sha256:889a6da2ed7ffc58ab5b900d888ddce90bce912f2d2de1dc1c26f4cb9fe65097"},
+    {file = "pkginfo-1.10.0.tar.gz", hash = "sha256:5df73835398d10db79f8eecd5cd86b1f6d29317589ea70796994d49399af6297"},
+]
+
+[package.extras]
+testing = ["pytest", "pytest-cov", "wheel"]
 
 [[package]]
 name = "platformdirs"
@@ -4709,4 +4732,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10.0,<3.12"
-content-hash = "a1765899290eed1deda9555cd96ad0655a6ff44c9dd61506df615e0f332c93de"
+content-hash = "015dbcc1eb3514efbdd0a5f32d4d9675e59bd7a307c6efeb2777202ccf2a7fe5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,8 @@ pytest-cov = "^4.1.0"
 optional = true
 
 [tool.poetry.group.web.dependencies]
-jupyterlite = ">=0.2.0,<0.3.0"
+jupyterlite = ">=0.3.0,<0.4.0"
+jupyterlite-pyodide-kernel = "^0.3.1"
 libarchive-c = ">=4,<6"
 pyyaml = "^6.0.1"
 


### PR DESCRIPTION
Also adds `jupyterlite-pyodide-kernel` as a dependency so that the kernel is recognized.
Without doing so, the Pyodide distribution we build will never be included in the JupyterLite output, therefore it is excluded from our GitHub Pages deployment.