### PR TITLE
fix: false positive pyodide build cache hits

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.231.6/containers/docker-existing-dockerfile
 {
-  "name": "Containerized Development Environment",
+  "name": "Default",
 
   // Building the container from the local, root-level Dockerfile
   "context": "..",

--- a/pyodide/build.py
+++ b/pyodide/build.py
@@ -291,6 +291,7 @@ def create_distro_build_script(pyodide_requirements: list) -> None:
     # Executing our custom cache downloader script
     pyodide_cache_dl = [
         "pip install pyyaml",
+        "source Makefile.envs",  # ensure the exported vars are available in `cache_dl.py` env
         f"python cache_dl.py --tag {PYODIDE_REPO_TAG}",
     ]
 

--- a/pyodide/build.py
+++ b/pyodide/build.py
@@ -291,7 +291,8 @@ def create_distro_build_script(pyodide_requirements: list) -> None:
     # Executing our custom cache downloader script
     pyodide_cache_dl = [
         "pip install pyyaml",
-        "source Makefile.envs",  # ensure the exported vars are available in `cache_dl.py` env
+        # ensure the exported vars are available in `cache_dl.py` env
+        "eval \"$(make -f Makefile.envs .output_vars | grep '=' | sed 's/^/export /')\"",
         f"python cache_dl.py --tag {PYODIDE_REPO_TAG}",
     ]
 

--- a/pyodide/cache_dl.py
+++ b/pyodide/cache_dl.py
@@ -40,6 +40,18 @@ def info(msg: str) -> None:
     print(f"{INFO_COLOR}Info: {msg}{ENDC}")
 
 
+def error(msg: str) -> None:
+    """
+    Prints an error message to stderr and exits with code 1.
+
+    :param msg: the error message to print
+    """
+    ERROR_COLOR = "\033[91m"
+    ENDC = "\033[0m"
+    print(f"{ERROR_COLOR}Error: {msg}{ENDC}", file=sys.stderr)
+    sys.exit(1)
+
+
 class LockfileInfo(TypedDict):
     arch: str
     platform: str
@@ -86,7 +98,13 @@ def resolve_sha256(sha256: str) -> str:
     import os
 
     if sha256.startswith("$("):
-        return os.getenv(sha256[2:-1])
+        varname = sha256[2:-1]
+        varvalue = os.getenv(varname)
+        if varvalue is None:
+            error(f"Available: {list(os.environ.keys())}")
+            raise ValueError(f"Environment variable '{varname}' not found")
+        return varvalue
+
     return sha256
 
 


### PR DESCRIPTION
Previously we used the built Pyodide package version as the cache key exclusively.

This yielded false positive cache hits when only the source code of a module changed (the sha256 signature), but not its version, as no official release took place. Therefore, we kept reusing built modules even though they were obsolete.

This PR introduces a fix by using `{version}@{sha256}` as the hash key.
Technically, `{sha256}` would be sufficient as a key, but including the version aids debugging.