### PR TITLE
ci: reduce workflow time by 10x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Build docker image
         run: docker build --build-arg PYTHON_VERSION=$(cat .python-version) -t draco .
 
-      - name: Run all make targets
-        run: docker run --rm draco bash -c "make"
+      - name: Test dockerized environment
+        run: docker run --rm draco bash -c "make env-test"
 
   automerge:
     needs:

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ test:
 	@echo "==> 🧪 Tests"
 	@uv run --all-extras pytest -svv $(PACKAGE_ROOT)
 
+.PHONY: env-test
+env-test: lint typecheck cover grounding-size
+
 # Default coverage report format
 COV_REPORT ?= term-missing
 


### PR DESCRIPTION
Currently our CI flows take ~13 minutes as the in-Docker build of JupyterBook docs take a long time due to notebook executions.

The `test-docker` job's sole responsibility is to verify that the in-Docker env is functional, running only the lint, test, grounding, etc. `make` targets should also be sufficient.

Making this change brings our CI time from ~13 minutes to ~1 minute.