### PR TITLE
feat: make Altair renderer more customizable

### DIFF
--- a/draco/renderer/altair/altair_renderer.py
+++ b/draco/renderer/altair/altair_renderer.py
@@ -1,16 +1,17 @@
 import logging
 import warnings
 from dataclasses import dataclass
-from typing import Any, Generic, Literal, TypeVar, cast
+from typing import Any, Callable, Generic, Literal, TypeVar, cast
 
 import altair as alt
+import narwhals as nw
 
-from draco.renderer.base_renderer import BaseRenderer, DataType
+import draco.renderer.utils as renderer_utils
+from draco.renderer.base_renderer import BaseRenderer, DataType, LabelMapping
 
 from .types import (
     Encoding,
     EncodingChannel,
-    Field,
     FieldName,
     FieldType,
     Mark,
@@ -46,6 +47,7 @@ class RootContext(Generic[VegaLiteChart]):
     spec: SpecificationDict
     chart: VegaLiteChart
     chart_views: list[VegaLiteChart]
+    get_label: Callable[[str], str | None]
 
 
 @dataclass(frozen=True)
@@ -85,20 +87,40 @@ class AltairRenderer(BaseRenderer[VegaLiteChart]):
     represented as an `Altair <https://altair-viz.github.io/>`_ chart object.
     """
 
-    def __init__(self, concat_mode: Literal["hconcat", "vconcat"] | None = None):
+    def __init__(
+        self,
+        concat_mode: Literal["hconcat", "vconcat"] | None = None,
+        mark_config: dict[str, dict[str, Any]] | None = None,
+    ):
         """
         Instantiates a new `Altair <https://altair-viz.github.io/>`-based renderer.
 
         :param concat_mode: The concatenation mode to use
                             when concatenating multiple views.
                             Only the first view is returned if `None`.
+        :param mark_config: Optional custom mark configuration.
+                            The keys are the mark types, the values are the
+                            configuration dictionaries for the mark type.
         """
         self.concat_mode = concat_mode
+        self.mark_config = mark_config or {}
 
-    def render(self, spec: dict, data: DataType) -> VegaLiteChart:
+    def render(
+        self, spec: dict, data: DataType, label_mapping: LabelMapping | None = None
+    ) -> VegaLiteChart:
         typed_spec = SpecificationDict.model_validate(spec)
         chart: VegaLiteChart = cast(VegaLiteChart, alt.Chart(data))
         chart_views: list[VegaLiteChart] = []
+        data_fields: list[str] = (
+            list(data.keys())
+            if isinstance(data, dict)
+            else nw.from_native(data).columns
+        )
+
+        def get_label(field: str) -> str | None:
+            if label_mapping is not None:
+                return renderer_utils.resolve_label(label_mapping, field)
+            return None
 
         # Traverse the specification dict and invoke the appropriate visitor
         for v in typed_spec.view:
@@ -112,6 +134,7 @@ class AltairRenderer(BaseRenderer[VegaLiteChart]):
                         layers=layers,
                         view=v,
                         mark=m,
+                        get_label=get_label,
                     )
                 )
                 for e in m.encoding:
@@ -124,8 +147,15 @@ class AltairRenderer(BaseRenderer[VegaLiteChart]):
                             view=v,
                             mark=m,
                             encoding=e,
+                            get_label=get_label,
                         )
                     )
+                chart = chart.encode(
+                    tooltip=[
+                        alt.Tooltip(field, title=get_label(field))
+                        for field in data_fields
+                    ]
+                )
                 layers.append(chart)
             chart = self.__visit_view(
                 ctx=ViewContext(
@@ -134,11 +164,18 @@ class AltairRenderer(BaseRenderer[VegaLiteChart]):
                     chart_views=chart_views,
                     layers=layers,
                     view=v,
+                    get_label=get_label,
                 )
             )
             chart_views.append(chart)
+
         return self.__visit_root(
-            ctx=RootContext(spec=typed_spec, chart=chart, chart_views=chart_views)
+            ctx=RootContext(
+                spec=typed_spec,
+                chart=chart,
+                chart_views=chart_views,
+                get_label=get_label,
+            )
         )
 
     def __visit_root(self, ctx: RootContext) -> VegaLiteChart:
@@ -187,10 +224,11 @@ class AltairRenderer(BaseRenderer[VegaLiteChart]):
             }
             for f in view.facet:
                 channel = f.channel
+                title_args = self.__get_title_args(ctx, f.field)
                 facet_args: dict[str, Any] = {
                     "field": f.field,
-                    "type": self.__get_field_type(ctx.spec, f.field),
-                }
+                    "type": self.__find_field_type(ctx.spec, f.field),
+                } | title_args
                 if f.binning is not None:
                     facet_args["bin"] = alt.BinParams(maxbins=f.binning)
                 match channel:
@@ -226,8 +264,7 @@ class AltairRenderer(BaseRenderer[VegaLiteChart]):
         # Should never happen, a pydantic error would be raised sooner
         raise ValueError(f"Unknown coordinate type: {coord}")  # pragma: no cover
 
-    @staticmethod
-    def __visit_mark_cartesian(ctx: MarkContext) -> VegaLiteChart:
+    def __visit_mark_cartesian(self, ctx: MarkContext) -> VegaLiteChart:
         """
         Handles mark-specific configuration.
         Responsible for applying the mark type to a chart in cartesian coordinates.
@@ -237,27 +274,27 @@ class AltairRenderer(BaseRenderer[VegaLiteChart]):
         :raises ValueError: if the mark type is not supported
         """
         chart, mark_type = (ctx.chart, ctx.mark.type)
+        mark_config = self.mark_config.get(mark_type, {})
         match mark_type:
             case "point":
-                return chart.mark_point()
+                return chart.mark_point(**mark_config)
             case "bar":
-                return chart.mark_bar()
+                return chart.mark_bar(**mark_config)
             case "line":
-                return chart.mark_line()
+                return chart.mark_line(**mark_config)
             case "area":
-                return chart.mark_area()
+                return chart.mark_area(**mark_config)
             case "text":
-                return chart.mark_text()
+                return chart.mark_text(**mark_config)
             case "tick":
-                return chart.mark_tick()
+                return chart.mark_tick(**mark_config)
             case "rect":
-                return chart.mark_rect()
+                return chart.mark_rect(**mark_config)
 
         # Should never happen, a pydantic error would be raised sooner
         raise ValueError(f"Unknown mark type: {mark_type}")  # pragma: no cover
 
-    @staticmethod
-    def __visit_mark_polar(ctx: MarkContext) -> VegaLiteChart:
+    def __visit_mark_polar(self, ctx: MarkContext) -> VegaLiteChart:
         """
         Handles mark-specific configuration.
         Responsible for applying the mark type to a chart in polar coordinates.
@@ -274,8 +311,12 @@ class AltairRenderer(BaseRenderer[VegaLiteChart]):
                     # We are setting a white stroke here so that the radial
                     # slices are visually separated from each other.
                     # See https://github.com/cmudig/draco2/pull/438#discussion_r1042469389  # noqa: E501
-                    return chart.mark_arc(stroke="#ffffff") + chart.mark_text(
-                        radiusOffset=15
+                    return chart.mark_arc(
+                        stroke="#ffffff",
+                        **self.mark_config.get("arc", {}),
+                    ) + chart.mark_text(
+                        radiusOffset=15,
+                        **self.mark_config.get("text", {}),
                     )
                 else:
                     return chart.mark_arc()
@@ -318,26 +359,28 @@ class AltairRenderer(BaseRenderer[VegaLiteChart]):
             ctx.mark,
             ctx.encoding,
         )
+        field_type = renderer_utils.find_raw_field_type(spec.field, encoding.field)
         custom_args: dict[str, Any] = {}
         if encoding.field is not None:
             custom_args["field"] = encoding.field
-            custom_args["type"] = self.__get_field_type(spec, encoding.field)
+            custom_args["type"] = self.__find_field_type(spec, encoding.field)
         if encoding.binning is not None:
             custom_args["bin"] = alt.BinParams(maxbins=encoding.binning)
 
         if view.scale is not None:
-            field_type = self.__get_field_type_raw(spec.field, encoding.field)
-            scale_or_none = self.__get_alt_scale_for_encoding(
+            scale_or_none = self.__find_alt_scale_for_encoding(
                 field_type, mark.type, encoding.channel, view.scale
             )
             if scale_or_none is not None:
                 custom_args["scale"] = scale_or_none
 
+        title_args = self.__get_title_args(ctx, encoding.field)
         encoding_args = (
             encoding.model_dump(
                 exclude_none=True, exclude={"channel", "field", "binning"}
             )
             | custom_args
+            | title_args
         )
 
         match encoding.channel:
@@ -379,21 +422,23 @@ class AltairRenderer(BaseRenderer[VegaLiteChart]):
         custom_args: dict[str, Any] = {}
         if encoding.field is not None:
             custom_args["field"] = encoding.field
-            custom_args["type"] = self.__get_field_type(spec, encoding.field)
+            custom_args["type"] = self.__find_field_type(spec, encoding.field)
 
         if view.scale is not None:
-            field_type = self.__get_field_type_raw(spec.field, encoding.field)
-            scale_or_none = self.__get_alt_scale_for_encoding(
+            field_type = renderer_utils.find_raw_field_type(spec.field, encoding.field)
+            scale_or_none = self.__find_alt_scale_for_encoding(
                 field_type, mark.type, encoding.channel, view.scale
             )
             if scale_or_none is not None:
                 custom_args["scale"] = scale_or_none
 
+        title_args = self.__get_title_args(ctx, encoding.field)
         encoding_args = (
             encoding.model_dump(
                 exclude_none=True, exclude={"channel", "field", "binning", "scale"}
             )
             | custom_args
+            | title_args
         )
 
         match encoding.channel:
@@ -416,65 +461,7 @@ class AltairRenderer(BaseRenderer[VegaLiteChart]):
                 raise ValueError(f"Unknown channel: {encoding.channel}")
 
     @staticmethod
-    def __get_encoding_channel_of_field(
-        views: list[View], field_name: FieldName
-    ) -> EncodingChannel | None:
-        """
-        Returns the mark encoding channel for the field with the given name.
-
-        :param views: All the views in the spec to search for.
-        :param field_name: The name of the field to search for.
-        :return: The encoding channel of the field, or `None` if
-                 the field is not found.
-        """
-        for v in views:
-            for m in v.mark:
-                for e in m.encoding:
-                    if e.field == field_name:
-                        return e.channel
-
-        return None
-
-    @staticmethod
-    def __get_scales_of_spec(spec: SpecificationDict) -> list[Scale]:
-        """
-        Returns all the scales in the spec including the top-level
-        shared scale and the view-specific scales.
-
-        :param spec: The spec to search through for scales.
-        :return: A list of all the scales in the spec.
-        """
-        scales: list[Scale] = []
-
-        # Shared scales
-        for s in spec.scale or []:
-            scales.append(s)
-
-        # View-specific scales
-        for v in spec.view:
-            for s in v.scale or []:
-                scales.append(s)
-
-        return scales
-
-    @staticmethod
-    def __get_field_by_name(fields: list[Field], field_name: FieldName) -> Field:
-        """
-        Returns the field with the given name.
-
-        :param fields: The list of fields to search through.
-        :param field_name: The name of the field to search for.
-        :return: The field with the given name.
-        :raises ValueError: If the field is not found.
-        """
-        for f in fields:
-            if f.name == field_name:
-                return f
-
-        raise ValueError(f"Field {field_name} not found")
-
-    @staticmethod
-    def __get_field_type(spec: SpecificationDict, field_name: FieldName) -> str:
+    def __find_field_type(spec: SpecificationDict, field_name: FieldName) -> str:
         """
         Returns the type of the field with the given name.
         Needed to map from Draco-spec data types to Vega-Lite data types.
@@ -484,7 +471,6 @@ class AltairRenderer(BaseRenderer[VegaLiteChart]):
         :param field_name: name of the field to look up
         :return: the type of the field
         """
-        cls = AltairRenderer
         __DEFAULT_KEY__ = "default"
         # Multi-criteria lookup to determine the type of the field
         # based on the scale type (if any) AND the raw data type.
@@ -517,50 +503,24 @@ class AltairRenderer(BaseRenderer[VegaLiteChart]):
             },
         }
 
-        field = cls.__get_field_by_name(spec.field, field_name)
+        field = renderer_utils.find_field_by_name(spec.field, field_name)
         # Look for the encoding channel of the field, so we can match it to a scale
-        channel = cls.__get_encoding_channel_of_field(spec.view, field_name)
+        channel = renderer_utils.find_encoding_channel_of_field(spec.view, field_name)
         # We might have no channel in case of a faceted field
         # --> we map based on the raw data type
         if channel is None:
             return renames[__DEFAULT_KEY__][field.type]
 
         # Look for the scale associated with `channel`
-        scale = cls.__get_scale_for_encoding(channel, cls.__get_scales_of_spec(spec))
+        scales_of_spec = renderer_utils.find_scales_of_spec(spec)
+        scale = renderer_utils.find_scale_for_encoding(channel, scales_of_spec)
         # We might have no scale present for the channel
         # --> we map based on the raw data type
         key = scale.type if scale is not None else __DEFAULT_KEY__
         return renames[key][field.type]
 
     @staticmethod
-    def __get_scale_for_encoding(
-        channel: EncodingChannel, scales: list[Scale]
-    ) -> Scale | None:
-        """
-        Returns the `Scale` for the given encoding channel, if any.
-
-        :param channel: the channel for which to look up a scale
-        :param scales: the list of scales in the view
-        :return: the scale for the given channel, or None if no scale is found
-        """
-        for scale in scales:
-            if scale.channel == channel:
-                return scale
-        return None
-
-    @staticmethod
-    def __get_field_type_raw(
-        fields: list[Field], field_name: FieldName | None
-    ) -> FieldType:
-        if field_name is None:
-            return "number"
-
-        cls = AltairRenderer
-        field_type = cls.__get_field_by_name(fields, field_name)
-        return field_type.type
-
-    @staticmethod
-    def __get_alt_scale_for_encoding(
+    def __find_alt_scale_for_encoding(
         field_type: FieldType,
         mark_type: MarkType,
         channel: EncodingChannel,
@@ -575,7 +535,7 @@ class AltairRenderer(BaseRenderer[VegaLiteChart]):
         :param scales: the list of scales in the view
         :return: the scale for the given channel, or None if no scale is found
         """
-        scale = AltairRenderer.__get_scale_for_encoding(channel, scales)
+        scale = renderer_utils.find_scale_for_encoding(channel, scales)
         if scale is None:
             return None
 
@@ -598,3 +558,10 @@ class AltairRenderer(BaseRenderer[VegaLiteChart]):
             del scale_args["type"]
 
         return alt.Scale(**scale_args) if scale_args else None
+
+    @staticmethod
+    def __get_title_args(ctx: RootContext, field: FieldName | None) -> dict[str, Any]:
+        if field is None or (label := ctx.get_label(field)) is None:
+            return {}
+
+        return {"title": label}

--- a/draco/renderer/base_renderer.py
+++ b/draco/renderer/base_renderer.py
@@ -1,9 +1,10 @@
 from abc import ABC, abstractmethod
-from typing import Any, Generic, TypeAlias, TypeVar, Union
+from typing import Any, Callable, Generic, TypeAlias, TypeVar, Union
 
 from narwhals.typing import IntoDataFrame
 
 DataType: TypeAlias = Union[dict[Any, Any], IntoDataFrame]
+LabelMapping: TypeAlias = Union[dict[str, str], Callable[[str], str]]
 
 T = TypeVar("T")
 
@@ -16,12 +17,17 @@ class BaseRenderer(ABC, Generic[T]):
     """
 
     @abstractmethod
-    def render(self, spec: dict, data: DataType) -> T:
+    def render(
+        self, spec: dict, data: DataType, label_mapping: LabelMapping | None = None
+    ) -> T:
         """
         Render a visualization from a dictionary-based specification and data.
 
         :param spec: Specification of the visualization.
         :param data: Data to render.
+        :param label_mapping: Mapping of field names to human-readable labels.
+            If a callable is provided, it will be called with the field name
+            and should return a human-readable label.
         :return: Produced visualization object of type `T`.
         """
         raise NotImplementedError  # pragma: no cover

--- a/draco/renderer/utils.py
+++ b/draco/renderer/utils.py
@@ -1,0 +1,98 @@
+from .altair.types import (
+    EncodingChannel,
+    Field,
+    FieldName,
+    FieldType,
+    Scale,
+    SpecificationDict,
+    View,
+)
+from .base_renderer import LabelMapping
+
+
+def find_encoding_channel_of_field(
+    views: list[View], field_name: FieldName
+) -> EncodingChannel | None:
+    """
+    Returns the mark encoding channel for the field with the given name.
+
+    :param views: All the views in the spec to search for.
+    :param field_name: The name of the field to search for.
+    :return: The encoding channel of the field, or `None` if
+             the field is not found.
+    """
+    for v in views:
+        for m in v.mark:
+            for e in m.encoding:
+                if e.field == field_name:
+                    return e.channel
+
+    return None
+
+
+def find_scales_of_spec(spec: SpecificationDict) -> list[Scale]:
+    """
+    Returns all the scales in the spec including the top-level
+    shared scale and the view-specific scales.
+
+    :param spec: The spec to search through for scales.
+    :return: A list of all the scales in the spec.
+    """
+    scales: list[Scale] = []
+
+    # Shared scales
+    for s in spec.scale or []:
+        scales.append(s)
+
+    # View-specific scales
+    for v in spec.view:
+        for s in v.scale or []:
+            scales.append(s)
+
+    return scales
+
+
+def find_field_by_name(fields: list[Field], field_name: FieldName) -> Field:
+    """
+    Returns the field with the given name.
+
+    :param fields: The list of fields to search through.
+    :param field_name: The name of the field to search for.
+    :return: The field with the given name.
+    :raises ValueError: If the field is not found.
+    """
+    for f in fields:
+        if f.name == field_name:
+            return f
+
+    raise ValueError(f"Field {field_name} not found")
+
+
+def find_scale_for_encoding(
+    channel: EncodingChannel, scales: list[Scale]
+) -> Scale | None:
+    """
+    Returns the `Scale` for the given encoding channel, if any.
+
+    :param channel: the channel for which to look up a scale
+    :param scales: the list of scales in the view
+    :return: the scale for the given channel, or None if no scale is found
+    """
+    for scale in scales:
+        if scale.channel == channel:
+            return scale
+    return None
+
+
+def find_raw_field_type(fields: list[Field], field_name: FieldName | None) -> FieldType:
+    if field_name is None:
+        return "number"
+
+    field_type = find_field_by_name(fields, field_name)
+    return field_type.type
+
+
+def resolve_label(label_mapping: LabelMapping, field_name: FieldName) -> str:
+    if isinstance(label_mapping, dict):
+        return label_mapping.get(field_name, field_name)
+    return label_mapping(field_name)

--- a/draco/tests/renderer/altair/test_altair_renderer.py
+++ b/draco/tests/renderer/altair/test_altair_renderer.py
@@ -1,5 +1,5 @@
 import random
-from typing import Literal
+from typing import Any, Literal
 
 import pandas as pd
 import pytest
@@ -11,6 +11,7 @@ from draco.renderer.altair.types import MarkType
 NUM_ROWS = 100
 df = pd.DataFrame(
     {
+        "date": pd.date_range("20230101", periods=NUM_ROWS),
         "temperature": [random.uniform(1, 44) for _ in range(NUM_ROWS)],
         "wind": [random.uniform(0, 100) for _ in range(NUM_ROWS)],
         "precipitation": [random.uniform(0, 100) for _ in range(NUM_ROWS)],
@@ -27,6 +28,7 @@ def data(fields):
         "field": [
             x
             for x in [
+                {"name": "date", "type": "datetime"},
                 {"name": "temperature", "type": "number"},
                 {"name": "wind", "type": "number"},
                 {"name": "precipitation", "type": "number"},
@@ -52,15 +54,32 @@ def renderer_with_hconcat():
     return AltairRenderer(concat_mode="hconcat")
 
 
-def vl_specs_equal(a: dict, b: dict) -> bool:
+@pytest.fixture
+def renderer_with_mark_config():
+    # Common use case ensuring that line charts have points shown without encoding them as a dedicated layer
+    return AltairRenderer(mark_config={"line": {"point": True}})
+
+
+def assert_vl_specs_equal(a: dict, b: dict):
     exclude_from_comparison = {"config", "datasets", "data", "$schema"}
+
+    def exclude_tooltip_callback(obj: Any, path: list[str] | None) -> bool:
+        if path and "tooltip" in path:
+            return True
+        return False
+
     diff = DeepDiff(
         a,
         b,
         exclude_paths=exclude_from_comparison,
+        exclude_obj_callback=exclude_tooltip_callback,
         ignore_order=True,
     )
-    return not diff
+
+    if diff:
+        raise AssertionError(
+            f"Vega-Lite specs differ:\n{diff.pretty()}"
+        )  # pragma: no cover
 
 
 def build_spec(*args):
@@ -431,7 +450,7 @@ def test_single_view_single_mark(
 ):
     chart = renderer.render(spec, df)
     vl = chart.to_dict()
-    assert vl_specs_equal(vl, expected_vl)
+    assert_vl_specs_equal(vl, expected_vl)
 
 
 # https://dig.cmu.edu/draco2/facts/examples.html#stacked-bar-chart
@@ -548,7 +567,7 @@ normalized_stacked_bar_spec_vl = {
 def test_stacked(spec: dict, expected_vl: dict, renderer: AltairRenderer):
     chart = renderer.render(spec, df)
     vl = chart.to_dict()
-    assert vl_specs_equal(vl, expected_vl)
+    assert_vl_specs_equal(vl, expected_vl)
 
 
 # https://dig.cmu.edu/draco2/facts/examples.html#bar-with-a-tick
@@ -616,7 +635,7 @@ bar_with_tick_spec_vl = {
 def test_multi_mark(spec: dict, expected_vl: dict, renderer: AltairRenderer):
     chart = renderer.render(spec, df)
     vl = chart.to_dict()
-    assert vl_specs_equal(vl, expected_vl)
+    assert_vl_specs_equal(vl, expected_vl)
 
 
 # https://dig.cmu.edu/draco2/facts/examples.html#facet-scatterplot-into-columns
@@ -751,6 +770,34 @@ scatterplot_columns_binned_spec_vl = {
         "mark": {"type": "point"},
     },
 }
+scatterplot_columns_binned_spec_titled_vl = {
+    "$schema": "https://vega.github.io/schema/vega-lite/v5.8.0.json",
+    "config": {"view": {"continuousHeight": 300, "continuousWidth": 400}},
+    "facet": {
+        "column": {
+            "bin": {"maxbins": 10},
+            "field": "temperature",
+            "type": "quantitative",
+            "title": "Temperature",
+        }
+    },
+    "spec": {
+        "encoding": {
+            "x": {
+                "field": "condition",
+                "type": "ordinal",
+                "title": "Condition",
+            },
+            "y": {
+                "field": "wind",
+                "scale": {"type": "linear"},
+                "type": "quantitative",
+                "title": "Wind",
+            },
+        },
+        "mark": {"type": "point"},
+    },
+}
 
 
 @pytest.mark.parametrize(
@@ -764,7 +811,7 @@ scatterplot_columns_binned_spec_vl = {
 def test_facets(spec: dict, expected_vl: dict, renderer: AltairRenderer):
     chart = renderer.render(spec, df)
     vl = chart.to_dict()
-    assert vl_specs_equal(vl, expected_vl)
+    assert_vl_specs_equal(vl, expected_vl)
 
 
 # https://dig.cmu.edu/draco2/facts/examples.html#tick-plot-and-histogram
@@ -915,7 +962,7 @@ def test_multiple_views_no_concat(
 ):
     chart = renderer.render(spec, df)
     vl = chart.to_dict()
-    assert vl_specs_equal(vl, expected_vl)
+    assert_vl_specs_equal(vl, expected_vl)
 
 
 @pytest.mark.parametrize(
@@ -938,7 +985,69 @@ def test_multiple_views_hconcat(
 ):
     chart = renderer_with_hconcat.render(spec, df)
     vl = chart.to_dict()
-    assert vl_specs_equal(vl, expected_vl)
+    assert_vl_specs_equal(vl, expected_vl)
+
+
+def test_renderer_with_literal_label_mapping(renderer: AltairRenderer):
+    spec = scatterplot_columns_binned_spec_d
+    expected_vl = scatterplot_columns_binned_spec_titled_vl
+    chart = renderer.render(
+        spec,
+        df,
+        label_mapping={col: col.capitalize() for col in df.columns},
+    )
+    vl = chart.to_dict()
+    assert_vl_specs_equal(vl, expected_vl)
+
+
+def test_renderer_with_dynamic_label_mapping(renderer: AltairRenderer):
+    spec = scatterplot_columns_binned_spec_d
+    expected_vl = scatterplot_columns_binned_spec_titled_vl
+    chart = renderer.render(
+        spec,
+        df,
+        label_mapping=lambda col: col.capitalize(),
+    )
+    vl = chart.to_dict()
+    assert_vl_specs_equal(vl, expected_vl)
+
+
+line_spec_with_mark_config_d = build_spec(
+    data(["date", "wind"]),
+    {
+        "view": [
+            {
+                "mark": [
+                    {
+                        "type": "line",
+                        "encoding": [
+                            {"channel": "x", "field": "date"},
+                            {"channel": "y", "field": "wind"},
+                        ],
+                    }
+                ],
+            }
+        ]
+    },
+)
+line_spec_with_mark_config_vl = {
+    "config": {"view": {"continuousWidth": 300, "continuousHeight": 300}},
+    # we are testing for the presence of point=True
+    "mark": {"type": "line", "point": True},
+    "encoding": {
+        "x": {"field": "date", "type": "temporal"},
+        "y": {"field": "wind", "type": "quantitative"},
+    },
+    "$schema": "https://vega.github.io/schema/vega-lite/v5.20.1.json",
+}
+
+
+def test_renderer_with_mark_config(renderer_with_mark_config: AltairRenderer):
+    spec = line_spec_with_mark_config_d
+    expected_vl = line_spec_with_mark_config_vl
+    chart = renderer_with_mark_config.render(spec, df)
+    vl = chart.to_dict()
+    assert_vl_specs_equal(vl, expected_vl)
 
 
 @pytest.mark.parametrize(
@@ -961,7 +1070,7 @@ def test_multiple_views_vconcat(
 ):
     chart = renderer_with_vconcat.render(spec, df)
     vl = chart.to_dict()
-    assert vl_specs_equal(vl, expected_vl)
+    assert_vl_specs_equal(vl, expected_vl)
 
 
 def test_unknown_field_raises_value_error(renderer: AltairRenderer):
@@ -1093,4 +1202,4 @@ polar_radial_chart_spec_vl = {
 def test_polar(spec: dict, expected_vl: dict, renderer: AltairRenderer):
     chart = renderer.render(spec, df)
     vl = chart.to_dict()
-    assert vl_specs_equal(vl, expected_vl)
+    assert_vl_specs_equal(vl, expected_vl)


### PR DESCRIPTION
- Enables mapping `technical_field_names` to `Nice Field Names` via literal dict or transformer callback
- Adds support to pass renderer-wide `mark_config` to support Vega-Lite features like `"point": true` for `line` marks and all other VL mark options